### PR TITLE
[LP#1940328] Add loadbalancer relation named lb-consumers

### DIFF
--- a/.github/workflows/naming-lint-unit.yaml
+++ b/.github/workflows/naming-lint-unit.yaml
@@ -11,3 +11,5 @@ jobs:
   lint-unit:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
+    with:
+      python: "['3.8', '3.9', '3.10', '3.11']"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .tox/
 __pycache__/
 *.pyc
+*.charm

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .tox/
 __pycache__/
 *.pyc
+.coverage
 *.charm

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -209,9 +209,9 @@ def manage_loadbalancer(
     fip_net = config["lb-floating-network"]
     manage_secgrps = config["manage-security-groups"]
     lb_manager = LoadBalancer.get_or_create(
-        app_name, lb_port, subnet, lb_algorithm, fip_net, manage_secgrps
+        app_name, str(lb_port), subnet, lb_algorithm, fip_net, manage_secgrps
     )
-    lb_manager.update_members(members)
+    lb_manager.update_members([(addr, str(port)) for addr, port in members])
     return lb_manager
 
 
@@ -983,6 +983,7 @@ class OctaviaLBImpl(BaseLBImpl):
 
     def create_member(self, member):
         addr, port = member
+        log(f"Creating lb member {addr}:{port} on {self.subnet} {self.name}")
         _openstack(
             "loadbalancer",
             "member",

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,7 +6,7 @@ description: |
   This charm can grant select permissions to instances of applications
   related to it which enable integration with OpenStack specific features,
   such as firewalls, load balancing, block storage, object storage, etc.
-docs: https://discourse.charmhub.io/t/openstack-integrator-docs-index/6093
+docs: https://discourse.charmhub.io/t/openstack-integrator-docs-index/12980
 maintainers: ['Cory Johns <cory.johns@canonical.com>']
 series:
   - jammy

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,6 +17,10 @@ provides:
     interface: openstack-integration
   credentials:
     interface: keystone-credentials
+  loadbalancer:
+    interface: public-address
+    # Use of this relation is strongly discouraged in favor of the more
+    # explicit lb-consumers relation.
   lb-consumers:
     interface: loadbalancer
 resources:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,8 +17,8 @@ provides:
     interface: openstack-integration
   credentials:
     interface: keystone-credentials
-  loadbalancer:
-    interface: public-address
+  lb-consumers:
+    interface: loadbalancer
 resources:
   openstackclients:
     type: file

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 from distutils.util import strtobool
 from charmhelpers.core import hookenv
 from charms.reactive import (
@@ -13,6 +14,12 @@ from charms.reactive import (
 from charms.reactive.relations import endpoint_from_name
 
 from charms import layer
+
+if TYPE_CHECKING:
+    from loadbalancer_interface.schemas.v1 import (
+        Request as LBRequest,
+        Response as LBResponse,
+    )
 
 SUPPORTED_LB_PROTOS = ["udp", "tcp"]
 SUPPORTED_LB_ALGS = ["ROUND_ROBIN", "LEAST_CONNECTIONS", "SOURCE_IP"]
@@ -161,11 +168,9 @@ def _lb_algo(request):
     return None
 
 
-def _validate_loadbalancer_request(request):
+def _validate_loadbalancer_request(request: "LBRequest") -> "LBResponse":
     """
     Validate the incoming request.
-
-    :return: None
     """
     response = request.response
     error_fields = response.error_fields = {}

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -15,7 +15,7 @@ from charms.reactive.relations import endpoint_from_name
 from charms import layer
 
 SUPPORTED_LB_PROTOS = ["udp", "tcp"]
-SUPPORTED_LB_ALGS = ["Default", "SourceIP", "SourceIPProtocol"]
+SUPPORTED_LB_ALGS = ["ROUND_ROBIN", "LEAST_CONNECTIONS", "SOURCE_IP"]
 SUPPORTED_LB_HC_PROTOS = ["http", "https", "tcp"]
 
 
@@ -153,8 +153,8 @@ def _lb_algo(request):
     """
     Choose a supported algorithm for the request.
     """
-    if not request.algorithm:
-        return "Default"
+    if not hasattr(request, "algorithm") or not request.algorithm:
+        return hookenv.config()["lb-method"]
     for supported in SUPPORTED_LB_ALGS:
         if supported in request.algorithm:
             return supported
@@ -193,32 +193,65 @@ def _validate_loadbalancer_request(request):
         if hc.path and hc.protocol.value not in ("http", "https"):
             error_fields["hc[{}].path".format(i)] = "Only valid with http(s) protocol"
 
+    config = hookenv.config()
+    lb_port = str(config["lb-port"])
+    remote_port = request.port_mapping.get(lb_port)
+    if not remote_port:
+        error_fields["ports"] = f"Not configured for {lb_port}"
+
     if error_fields:
         hookenv.log("Unsupported features: {}".format(error_fields), hookenv.ERROR)
     return response
 
 
-@when_all("charm.openstack.creds.set", "endpoint.lb-consumers.requests_changed")
+@when_all("charm.openstack.creds.set", "endpoint.loadbalancer.joined")
 @when_not("upgrade.series.in-progress")
-def create_or_update_loadbalancers():
+def manage_loadbalancers_via_loadbalancer():
     layer.status.maintenance("Managing load balancers")
     config = hookenv.config()
-    lb_consumers = allow_lb_consumers_to_read_requests()
     lb_port = str(config["lb-port"])
+    lb_clients = endpoint_from_name("loadbalancer")
+    try:
+        for request in lb_clients.requests:
+            if not request.members:
+                continue
+            lb = layer.openstack.manage_loadbalancer(
+                request.application_name,
+                request.members,
+                lb_port,
+                _lb_algo(request),
+                "loadbalancer",
+            )
+            request.set_address_port(lb.fip or lb.address, lb.port)
+    except layer.openstack.OpenStackError as e:
+        layer.status.blocked(str(e))
+
+
+@when_all("charm.openstack.creds.set", "endpoint.lb-consumers.requests_changed")
+@when_not("upgrade.series.in-progress")
+def manage_loadbalancers_via_lb_consumers():
+    layer.status.maintenance("Managing load balancers")
+    config = hookenv.config()
+    lb_port = str(config["lb-port"])
+    lb_consumers = allow_lb_consumers_to_read_requests()
     errors = []
     for request in lb_consumers.new_requests:
         response = _validate_loadbalancer_request(request)
-        if not response.error_fields:
-            try:
-                members = [
-                    (addr, request.port_mapping[lb_port]) for addr in request.backends
-                ]
-                lb = layer.openstack.manage_loadbalancer(request.name, members)
-                request.address = lb.fip or lb.address
-            except layer.openstack.OpenStackError as e:
-                response.error = response.error_types.provider_error
-                response.error_message = str(e)
-                errors.append(str(e))
+        if response.error_fields:
+            lb_consumers.send_response(request)
+            continue
+
+        remote_port = request.port_mapping[lb_port]
+        try:
+            members = [(addr, remote_port) for addr in request.backends]
+            lb = layer.openstack.manage_loadbalancer(
+                request.name, members, lb_port, _lb_algo(request), "lb-consumers"
+            )
+            request.address = lb.fip or lb.address
+        except layer.openstack.OpenStackError as e:
+            response.error = response.error_types.provider_error
+            response.error_message = str(e)
+            errors.append(str(e))
         lb_consumers.send_response(request)
     if errors:
         layer.status.blocked(", ".join(errors))

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -1,0 +1,23 @@
+description: Overlay for attaching current charm
+applications:
+  kubernetes-control-plane:
+    options:
+      allow-privileged: "true"
+  openstack-integrator:
+    charm: {{charm}}
+    trust: true
+  openstack-cloud-controller:
+    charm: openstack-integrator
+    channel: edge
+  cinder-csi:
+    charm: cinder-csi
+    channel: edge
+relations:
+- [openstack-cloud-controller:certificates, easyrsa:client]
+- [openstack-cloud-controller:kube-control, kubernetes-control-plane:kube-control]
+- [openstack-cloud-controller:external-cloud-provider, kubernetes-control-plane:external-cloud-provider]
+- [openstack-cloud-controller:openstack, openstack-integrator:clients]
+- [cinder-csi:certificates, easyrsa:client]
+- [cinder-csi:kube-control, kubernetes-control-plane:kube-control]
+- [cinder-csi:openstack, openstack-integrator:clients]
+- [kubernetes-control-plane:loadbalancer-external, openstack-integrator:lb-consumer]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,52 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+import logging
+import random
+import string
+from pathlib import Path
+
+import pytest
+from lightkube import AsyncClient, KubeConfig
+from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.core_v1 import Namespace
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def module_name(request):
+    return request.module.__name__.replace("_", "-")
+
+
+@pytest.fixture()
+async def kubeconfig(ops_test):
+    kubeconfig_path = ops_test.tmp_path / "kubeconfig"
+    retcode, stdout, stderr = await ops_test.run(
+        "juju",
+        "scp",
+        "kubernetes-control-plane/leader:/home/ubuntu/config",
+        kubeconfig_path,
+    )
+    if retcode != 0:
+        log.error(f"retcode: {retcode}")
+        log.error(f"stdout:\n{stdout.strip()}")
+        log.error(f"stderr:\n{stderr.strip()}")
+        pytest.fail("Failed to copy kubeconfig from kubernetes-control-plane")
+    assert Path(kubeconfig_path).stat().st_size, "kubeconfig file is 0 bytes"
+    yield kubeconfig_path
+
+
+@pytest.fixture()
+async def kubernetes(kubeconfig, module_name):
+    rand_str = "".join(random.choices(string.ascii_lowercase + string.digits, k=5))
+    namespace = f"{module_name}-{rand_str}"
+    config = KubeConfig.from_file(kubeconfig)
+    client = AsyncClient(
+        config=config.get(context_name="juju-context"),
+        namespace=namespace,
+        trust_env=False,
+    )
+    namespace_obj = Namespace(metadata=ObjectMeta(name=namespace))
+    await client.create(namespace_obj)
+    yield client
+    await client.delete(Namespace, namespace)

--- a/tests/integration/test_openstack_integrator_integration.py
+++ b/tests/integration/test_openstack_integrator_integration.py
@@ -1,6 +1,12 @@
+import asyncio
 import logging
 import pytest
 import shlex
+from pathlib import Path
+
+from lightkube.codecs import from_dict
+from lightkube.resources.core_v1 import Node
+
 
 log = logging.getLogger(__name__)
 
@@ -8,45 +14,115 @@ log = logging.getLogger(__name__)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test):
     """Build and deploy openstack-integrator in bundle."""
-    bundle = ops_test.Bundle("kubernetes-core", channel="edge")
-    (bundle,) = await ops_test.async_render_bundles(bundle)
-    log.info("Deploy Kubernetes Core...")
+    charm = next(Path(".").glob("openstack-integrator*.charm"), None)
+    if not charm:
+        log.info("Build Charm...")
+        charm = await ops_test.build_charm(".")
 
-    deploy = shlex.split(f"juju deploy -m {ops_test.model_full_name} {bundle}")
-    rc, stdout, stderr = await ops_test.run(*deploy)
+    overlays = [
+        ops_test.Bundle("kubernetes-core", channel="edge"),
+        Path("tests/data/charm.yaml"),
+    ]
+
+    bundle, *overlays = await ops_test.async_render_bundles(
+        *overlays, charm=charm.resolve()
+    )
+
+    log.info("Deploy Charm...")
+    model = ops_test.model_full_name
+    cmd = f"juju deploy -m {model} {bundle} " + " ".join(
+        f"--overlay={f} --trust" for f in overlays
+    )
+    rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))
     assert rc == 0, f"Bundle deploy failed: {(stderr or stdout).strip()}"
+
     log.info(stdout)
+    await ops_test.model.block_until(
+        lambda: "openstack-integrator" in ops_test.model.applications, timeout=60
+    )
 
     await ops_test.model.wait_for_idle(wait_for_active=True, timeout=60 * 60)
-
-    charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(f"local:{charm}", to="lxd:0", trust=True)
-    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=10 * 60)
-
-
-async def test_add_relations(ops_test):
-    """Test adding openstack-integrator relations.
-
-    This will test adding relations
-    `openstack-integrator:clients kubernetes-control-plane:openstack` and
-    `openstack-integrator:clients kubernetes-worker:openstack`.
-    """
-    await ops_test.model.relate(
-        "openstack-integrator:clients", "kubernetes-control-plane:openstack"
-    )
-    await ops_test.model.relate(
-        "openstack-integrator:clients", "kubernetes-worker:openstack"
-    )
-    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=10 * 60)
 
 
 async def test_status_messages(ops_test):
     """Validate that the status messages are correct."""
     expected_messages = {
-        "kubernetes-control-plane": "Kubernetes control-plane running.",
-        "kubernetes-worker": "Kubernetes worker running.",
+        "kubernetes-control-plane": "",
+        "kubernetes-worker": "",
         "openstack-integrator": "Ready",
     }
     for app, message in expected_messages.items():
         for unit in ops_test.model.applications[app].units:
             assert unit.workload_status_message == message
+
+
+async def test_provider_ids(kubernetes):
+    async for node in kubernetes.list(Node):
+        assert node.spec.providerID.startswith("openstack://")
+
+
+@pytest.fixture
+async def pod_with_volume(kubernetes, ops_test):
+    name = ops_test.model_name
+    pvc = from_dict(
+        dict(
+            kind="PersistentVolumeClaim",
+            apiVersion="v1",
+            metadata=dict(name=name, labels=dict(claim_pvc="pvc")),
+            spec=dict(
+                accessModes=["ReadWriteOnce"],
+                resources=dict(requests=dict(storage="10Mi")),
+                storageClassName="csi-cinder-default",
+            ),
+        )
+    )
+    busybox = from_dict(
+        dict(
+            kind="Pod",
+            apiVersion="v1",
+            metadata=dict(name=name, labels=dict(claim_pvc="pod")),
+            spec=dict(
+                containers=[
+                    dict(
+                        image="rocks.canonical.com/cdk/busybox:1.36",
+                        command=["sleep", "3600"],
+                        imagePullPolicy="IfNotPresent",
+                        name="busybox",
+                        volumeMounts=[dict(mountPath="/pv", name="testvolume")],
+                    )
+                ],
+                restartPolicy="Always",
+                volumes=[
+                    dict(name="testvolume", persistentVolumeClaim=dict(claimName=name))
+                ],
+            ),
+        )
+    )
+    await asyncio.gather(
+        *[
+            kubernetes.create(rsc, namespace=rsc.metadata.namespace)
+            for rsc in [pvc, busybox]
+        ]
+    )
+    yield busybox
+    await asyncio.gather(
+        *[
+            kubernetes.delete(type(rsc), name=name, namespace=rsc.metadata.namespace)
+            for rsc in [pvc, busybox]
+        ]
+    )
+
+
+async def test_create_persistent_volume(kubernetes, pod_with_volume):
+    _fix = pod_with_volume
+    res, name, namespace = type(_fix), _fix.metadata.name, _fix.metadata.namespace
+    try:
+        pod = await asyncio.wait_for(
+            kubernetes.wait(
+                res, name, namespace=namespace, for_conditions=["ContainersReady"]
+            ),
+            timeout=30.0,
+        )
+    except asyncio.TimeoutError as e:
+        raise AssertionError("Timeout waiting for pod to be ready") from e
+    assert pod.status.phase == "Running"

--- a/tests/unit/test_openstack_integrator.py
+++ b/tests/unit/test_openstack_integrator.py
@@ -9,7 +9,6 @@ from unittest import mock
 import subprocess
 from urllib.request import urlopen
 from urllib.error import HTTPError
-from time import sleep
 import charms.layer
 
 from charms.unit_test import patch_fixture
@@ -388,7 +387,8 @@ def test_wait_not_pending(impl):
             {"provisioning_status": "ACTIVE"},
         ]
     )
-    lb._wait_not_pending(test_func)
+    with mock.patch.object(openstack, "sleep") as sleep:
+        lb._wait_not_pending(test_func)
     assert sleep.call_count == 3
 
     test_func = mock.Mock(

--- a/tests/unit/test_openstack_integrator.py
+++ b/tests/unit/test_openstack_integrator.py
@@ -206,17 +206,18 @@ def test_manage_loadbalancer(mock_lb, mock_subnet):
         "manage-security-groups": False,
     }
     lb_manager = mock_lb.get_or_create.return_value
+    members = [("1.2.3.4", 80)]
     assert (
         openstack.manage_loadbalancer(
-            "my-ha-app", [], lb_port, lb_method, "lb-consumers"
+            "my-ha-app", members, lb_port, lb_method, "lb-consumers"
         )
         is lb_manager
     )
-    mock_subnet.assert_called_once_with([], "lb-consumers")
+    mock_subnet.assert_called_once_with(members, "lb-consumers")
     mock_lb.get_or_create.assert_called_once_with(
         "my-ha-app", lb_port, mock_subnet.return_value, lb_method, "fip-network", False
     )
-    lb_manager.update_members.assert_called_once_with([])
+    lb_manager.update_members.assert_called_once_with([("1.2.3.4", "80")])
 
 
 @mock.patch.object(openstack.LoadBalancer, "_add_member_sg")

--- a/tests/unit/test_openstack_integrator.py
+++ b/tests/unit/test_openstack_integrator.py
@@ -174,14 +174,49 @@ def test_run_with_creds(_load_creds):
 
 def test_default_subnet(_openstack):
     members = [("192.168.0.1", 80), ("10.0.0.1", 80)]
+    endpoint = "unused"
     _openstack.return_value = [
         {"Name": "a", "Subnet": "192.168.0.0/24"},
         {"Name": "b", "Subnet": "10.0.0.0/16"},
     ]
-    assert openstack._default_subnet(members) == "a"
-    assert openstack._default_subnet(list(reversed(members))) == "b"
+    openstack.hookenv.unit_get.return_value = "192.168.0.2"
+    openstack.hookenv.network_get.side_effect = [
+        {},
+        {"ingress-addresses": ["10.0.0.2", "252.0.162.1"]},
+    ]
+
+    assert openstack._default_subnet(members, endpoint) == "a"
+    assert openstack._default_subnet([], endpoint) == "a"
+    assert openstack._default_subnet([], endpoint) == "b"
+    assert openstack._default_subnet(list(reversed(members)), endpoint) == "b"
     with pytest.raises(openstack.OpenStackLBError):
-        openstack._default_subnet([("10.1.0.1", 80)])
+        openstack._default_subnet([("10.1.0.1", 80)], endpoint)
+
+
+@mock.patch.object(openstack, "_default_subnet")
+@mock.patch.object(openstack, "LoadBalancer")
+def test_manage_loadbalancer(mock_lb, mock_subnet):
+    lb_method = "ROUND_ROBIN"
+    lb_port = "6443"
+    openstack.config = {
+        "lb-subnet": "",
+        "lb-floating-network": "fip-network",
+        "lb-port": lb_port,
+        "lb-method": lb_method,
+        "manage-security-groups": False,
+    }
+    lb_manager = mock_lb.get_or_create.return_value
+    assert (
+        openstack.manage_loadbalancer(
+            "my-ha-app", [], lb_port, lb_method, "lb-consumers"
+        )
+        is lb_manager
+    )
+    mock_subnet.assert_called_once_with([], "lb-consumers")
+    mock_lb.get_or_create.assert_called_once_with(
+        "my-ha-app", lb_port, mock_subnet.return_value, lb_method, "fip-network", False
+    )
+    lb_manager.update_members.assert_called_once_with([])
 
 
 @mock.patch.object(openstack.LoadBalancer, "_add_member_sg")

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps =
     ipdb
     git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
     python-openstackclient
+    -r wheelhouse.txt
 commands = pytest --tb native -s -v {posargs} {toxinidir}/tests/unit
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -22,12 +22,15 @@ setenv =
 [testenv:unit]
 deps =
     pyyaml
-    pytest
+    pytest-cov
     ipdb
     git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
     python-openstackclient
     -r wheelhouse.txt
-commands = pytest --tb native -s -v {posargs} {toxinidir}/tests/unit
+commands = 
+    pytest --tb native -s -v \
+       --cov-report term-missing --cov=lib \
+       {posargs} {toxinidir}/tests/unit
 
 [testenv:lint]
 deps = 

--- a/tox.ini
+++ b/tox.ini
@@ -46,8 +46,9 @@ commands = black {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests
 
 [testenv:integration]
 deps =
-    juju < 3.1
+    juju
     pytest
     pytest-operator
+    lightkube
     ipdb
 commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,0 +1,1 @@
+loadbalancer_interface


### PR DESCRIPTION
[LP#1940328](https://bugs.launchpad.net/charm-openstack-integrator/+bug/1940328)

It's a long time coming, but we're finally going to address this bug by adding the lb-consumer to this charm, updating it to support both the old `loadbalancer:public-http` relation as the current `lb-consumers:loadbalancer` relation. 

By supporting both -- the 1.28/stable charms can relate to this updated charm, then migrate to the `lb-consumers` relatoin