### PR TITLE
Adds project-id to the o7k credentials

### DIFF
--- a/.github/workflows/naming-lint-unit.yaml
+++ b/.github/workflows/naming-lint-unit.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 jobs:
   call-inclusive-naming-check:
     name: Inclusive Naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
 
@@ -12,4 +12,4 @@ jobs:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
     with:
-      python: "['3.8', '3.9', '3.10', '3.11']"
+      python: "['3.8', '3.10', '3.12']"

--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,10 @@ options:
     description: Password of a valid user set in keystone.
     type: string
     default: ""
+  project-id:
+    description: ID of project where you want to create your resources.
+    type: string
+    default: ""
   project-name:
     description: Name of project where you want to create your resources.
     type: string

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -60,6 +60,7 @@ def update_credentials():
         "project_name",
     ]
     optional_fields = [
+        "project_id",
         "endpoint_tls_ca",
     ]
     # pre-populate with empty values to avoid key and arg errors
@@ -286,6 +287,7 @@ def _normalize_creds(creds_data):
         password=attrs.get("password"),
         user_domain_name=attrs.get("user-domain-name"),
         project_domain_name=attrs.get("project-domain-name"),
+        project_id=attrs.get("project-id"),
         project_name=attrs.get("project-name", attrs.get("tenant-name")),
         endpoint_tls_ca=ca_cert,
         version=_determine_version(attrs, endpoint, ca_cert),
@@ -324,6 +326,7 @@ def _run_with_creds(*args):
         "OS_PASSWORD": creds["password"],
         "OS_REGION_NAME": creds["region"],
         "OS_USER_DOMAIN_NAME": creds["user_domain_name"],
+        "OS_PROJECT_ID": creds["project_id"],
         "OS_PROJECT_NAME": creds["project_name"],
         "OS_PROJECT_DOMAIN_NAME": creds["project_domain_name"],
     }

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -38,6 +38,7 @@ def set_app_ver():
     "config.changed.username",
     "config.changed.password",
     "config.changed.project-name",
+    "config.changed.project-id",
     "config.changed.user-domain-name",
     "config.changed.project-domain-name",
     "config.changed.region",

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING
-from distutils.util import strtobool
+from str2bool import str2bool
 from charmhelpers.core import hookenv
 from charms.reactive import (
     hook,
@@ -101,7 +101,7 @@ def handle_requests():
     config = hookenv.config()
     has_octavia = layer.openstack.detect_octavia()
     try:
-        manage_security_groups = strtobool(config["manage-security-groups"])
+        manage_security_groups = str2bool(config["manage-security-groups"])
         # use bool() to force True / False instead of 1 / 0
         manage_security_groups = bool(manage_security_groups)
     except ValueError:

--- a/tests/unit/test_openstack_integrator.py
+++ b/tests/unit/test_openstack_integrator.py
@@ -127,6 +127,7 @@ def test_run_with_creds(_load_creds):
         "password": "password",
         "user_domain_name": "user_domain_name",
         "project_domain_name": "project_domain_name",
+        "project_id": "project_id",
         "project_name": "project_name",
         "endpoint_tls_ca": _b64("endpoint_tls_ca"),
         "version": "3",
@@ -145,6 +146,7 @@ def test_run_with_creds(_load_creds):
             "OS_REGION_NAME": "region",
             "OS_USER_DOMAIN_NAME": "user_domain_name",
             "OS_PROJECT_NAME": "project_name",
+            "OS_PROJECT_ID": "project_id",
             "OS_PROJECT_DOMAIN_NAME": "project_domain_name",
             "OS_IDENTITY_API_VERSION": "3",
             "OS_CACERT": str(openstack.CA_CERT_FILE),
@@ -637,6 +639,7 @@ def test_update_credentials(_normalize_creds, _save_creds, log_err):
     expected = config.copy()
     del expected["credentials"]
     expected["endpoint_tls_ca"] = ""
+    expected["project_id"] = ""
     assert openstack.update_credentials() is True
     _save_creds.assert_called_with(expected)
 
@@ -679,6 +682,7 @@ def test_normalize_creds(_determine_version, log_err):
         password=None,
         user_domain_name=None,
         project_domain_name=None,
+        project_id=None,
         project_name=None,
         endpoint_tls_ca=None,
         version="3",
@@ -690,6 +694,7 @@ def test_normalize_creds(_determine_version, log_err):
         "username": "username",
         "password": "password",
         "user-domain-name": "user-domain-name",
+        "project-id": "project-id",
         "project-domain-name": "project-domain-name",
         "tenant-name": "tenant-name",
     }
@@ -700,6 +705,7 @@ def test_normalize_creds(_determine_version, log_err):
         password="password",
         user_domain_name="user-domain-name",
         project_domain_name="project-domain-name",
+        project_id="project-id",
         project_name="tenant-name",
         endpoint_tls_ca=None,
         version="3",
@@ -712,6 +718,9 @@ def test_normalize_creds(_determine_version, log_err):
             "credential": {"attributes": attrs},
         }
     ) == dict(expected, auth_url="endpoint", region="region")
+
+    attrs["project-id"] = expected["project_id"] = "project-id"
+    assert openstack._normalize_creds(attrs) == expected
 
     attrs["project-name"] = expected["project_name"] = "project-name"
     assert openstack._normalize_creds(attrs) == expected

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     python-openstackclient
     -r wheelhouse.txt
 commands = 
-    pytest --tb native -s -v \
+    pytest --tb native -s -vv \
        --cov-report term-missing --cov=lib \
        {posargs} {toxinidir}/tests/unit
 

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,2 @@
 loadbalancer_interface
+str2bool


### PR DESCRIPTION
## Overview
Addresses [LP#2075524](https://bugs.launchpad.net/charm-openstack-cloud-controller/+bug/2075524) by adding `PROJECT_ID` when available in the credentials

### Details
* In some cases, the project-id is necessary to be shared across the cluster as part of the o7k credentials. 

### Dependencies
* https://github.com/canonical/interface-openstack-integration/pull/16
