### PR TITLE
Address mishandled config of manage-security-group

### DIFF
--- a/tests/unit/test_reactive_openstack.py
+++ b/tests/unit/test_reactive_openstack.py
@@ -1,0 +1,17 @@
+import pytest
+
+from reactive.openstack import lb_manage_security_groups
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (True, True),
+        (False, False),
+        ("yes", True),
+        ("invalid", None),
+    ],
+)
+def test_lb_secgroup_valid(value, expected):
+    config = {"manage-security-groups": value}
+    assert lb_manage_security_groups(config) is expected

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     -r wheelhouse.txt
 commands = 
     pytest --tb native -s -vv \
-       --cov-report term-missing --cov=lib \
+       --cov-report term-missing --cov=lib --cov=reactive \
        {posargs} {toxinidir}/tests/unit
 
 [testenv:lint]


### PR DESCRIPTION
###Overview
Addresses [LP#2095043](https://launchpad.net/bugs/2095043)

### Details
Poorly mishandled configuration management led to this issue creeping into the 1.31 release when we first supported building of these charms on python 3.12.  

* `str2bool` is only good for strings, not so good on things that are already boolean
* adjusts tests to confirm the value is true or false
