### PR TITLE
Pinning pbr<6.1.1 so it continues to use setuptools

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,2 +1,3 @@
 loadbalancer_interface
 str2bool
+pbr<6.1.1


### PR DESCRIPTION
fix: pin the version of pbr to a package that still uses setuptools.

Resolves [LP#2098017](https://bugs.launchpad.net/charm-openstack-integrator/+bug/2098017) 