### PR TITLE
[LP#1905008] Use subnet cidr for member secgroup rules to support amphora VRRP_IP

### DIFF
--- a/src/lib/charms/layer/openstack.py
+++ b/src/lib/charms/layer/openstack.py
@@ -571,7 +571,8 @@ class LoadBalancer:
             # If using Octavia the SG will have been created by Octavia and
             # therefore only an admin or Octavia itself can access it.
             if self.sg_id:
-                self._impl.create_sg_rule(sg_id, self.address, self.port)
+                subnet_cidr = self._impl.get_subnet_cidr(self.subnet)
+                self._impl.create_sg_rule(sg_id, subnet_cidr, self.port)
                 log(
                     "Added rule for {}:{} to security group {} ({})",
                     self.address,
@@ -744,7 +745,8 @@ class LoadBalancer:
         ):
             self._impl.set_port_secgrp(port_id, self.member_sg_id)
         if not self._find_matching_sg_rule(self.member_sg_id, self.address, port):
-            self._impl.create_sg_rule(self.member_sg_id, self.address, port)
+            subnet_cidr = self._impl.get_subnet_cidr(self.subnet)
+            self._impl.create_sg_rule(self.member_sg_id, subnet_cidr, port)
 
     def delete(self):
         """Delete this loadbalancer and all of its resources."""


### PR DESCRIPTION
This fixes [LP#1905008](https://bugs.launchpad.net/charm-openstack-integrator/+bug/1905008) by using the subnet cidr for member rules allowing the health checks to succeed since they use the amphora VRRP_IP and not the ip of the loadbalancer.