### PR TITLE
 feat: Launchpad Builds

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,7 +21,9 @@ parts:
     - https://raw.githubusercontent.com/charmed-kubernetes/layer-index/main/
     - --debug
     - --force
-    build-snaps: 
+    build-packages:
+    - python3-dev
+    build-snaps:
     - charm/3.x/stable
     build-environment:
     - CHARM_INTERFACES_DIR: $CRAFT_PROJECT_DIR/interfaces/

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,15 +13,15 @@ variable "base" {
   default     = "ubuntu@22.04"
 
   validation {
-    condition     = contains(["ubuntu@20.04", "ubuntu@22.04"], var.base)
-    error_message = "Base must be one of ubuntu@20.04, ubuntu@22.04"
+    condition     = contains(["ubuntu@22.04", "ubuntu@24.04"], var.base)
+    error_message = "Base must be one of ubuntu@22.04, ubuntu@24.04"
   }
 }
 
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "1.31/stable"
+  default     = "latest/stable"
 }
 
 variable "config" {


### PR DESCRIPTION
### Overview
After merging #15, launchpad builds of this charm are failing with missing `Python.h` from `python3-dev` package. 

### Details
* use `build-packages` since python3 dev packages are needed on launchpad builders
* also need to update the terraform/variable defaults after dropping focal and adding noble