### PR TITLE
Allow juju admin to specify o7k endpoint proxy values by charm or model

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -174,9 +174,9 @@ options:
       using juju's model-config juju-*-proxy settings.
       (See https://documentation.ubuntu.com/juju/latest/reference/juju-cli/list-of-juju-cli-commands/model-config/).
 
-      Choices are "", "openstack-client", or "integrations" or any combination
+      Choices are "", "openstack-client", or "clients" or any combination
 
       * "openstack-client", the local openstack-client application will be proxied
-      * "integrations", the proxy information will be passed to requirers of the openstack-integrators interface
+      * "clients", the proxy information will be passed to requirers on the clients relation
     type: string
     default: ""

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -168,16 +168,15 @@ options:
       (no floating IP) by default.
     type: boolean
     default: false
-  proxy-source:
+  proxy-applications:
     description: |
-      The source of the proxy configuration. This is used to configure the
-      OpenStack clients via the relation as well as all charm http requests.
-
-      * As "none", ignore proxy settings
-      * As "model", use the proxy settings from the model configuration
-
+      A comma separated list of applications managed by this charm to be proxied
+      using juju's model-config juju-*-proxy settings.
       (See https://documentation.ubuntu.com/juju/latest/reference/juju-cli/list-of-juju-cli-commands/model-config/).
 
-      Valid values are: "none" or "model". The default is "none".
+      Choices are "", "openstack-client", or "subordinates" or any combination
+
+      * "openstack-client", the local openstack-client application will be proxied
+      * "subordinates", the proxy information will be passed to subordinates of this primary
     type: string
-    default: "none"
+    default: ""

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -168,7 +168,7 @@ options:
       (no floating IP) by default.
     type: boolean
     default: false
-  model-proxy-enable:
+  juju-model-proxy-enable:
     type: boolean
     description: |
       Whether the applications managed by this charm should be

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -168,38 +168,16 @@ options:
       (no floating IP) by default.
     type: boolean
     default: false
-  http-proxy:
-    description: |
-      The HTTP proxy to use for outgoing requests. This is used to configure
-      the OpenStack clients via the relation as well as all internal charm http
-      requests.
-    type: string
-    default: ""
-  https-proxy:
-    description: |
-      The HTTPS proxy to use for outgoing requests. This is used to configure
-      the OpenStack clients via the relation as well as all internal charm http
-      requests.
-    type: string
-    default: ""
-  no-proxy:
-    description: |
-      A comma-separated list of hosts and cidrs that excluded from proxying.
-      This is used to configure the OpenStack clients via the relation as well
-      as all internal charm http requests.
-    type: string
-    default: ""
   proxy-source:
     description: |
       The source of the proxy configuration. This is used to configure the
-      OpenStack clients via the relation as well as all internal charm http
-      requests.
+      OpenStack clients via the relation as well as all charm http requests.
 
-      * As "charm", use the proxy settings from the configuration options above.
+      * As "none", ignore proxy settings
       * As "model", use the proxy settings from the model configuration
 
       (See https://documentation.ubuntu.com/juju/latest/reference/juju-cli/list-of-juju-cli-commands/model-config/).
 
-      Valid values are: "charm" or "model". The default is "charm".
+      Valid values are: "none" or "model". The default is "none".
     type: string
-    default: "charm"
+    default: "none"

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -168,15 +168,10 @@ options:
       (no floating IP) by default.
     type: boolean
     default: false
-  proxy-applications:
+  model-proxy-enable:
+    type: boolean
     description: |
-      A comma separated list of applications managed by this charm to be proxied
-      using juju's model-config juju-*-proxy settings.
+      Whether the applications managed by this charm should be
+      proxied using juju's model-config juju-*-proxy settings.
       (See https://documentation.ubuntu.com/juju/latest/reference/juju-cli/list-of-juju-cli-commands/model-config/).
-
-      Choices are "", "openstack-client", or "clients" or any combination
-
-      * "openstack-client", the local openstack-client application will be proxied
-      * "clients", the proxy information will be passed to requirers on the clients relation
-    type: string
-    default: ""
+    default: false

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -168,3 +168,38 @@ options:
       (no floating IP) by default.
     type: boolean
     default: false
+  http-proxy:
+    description: |
+      The HTTP proxy to use for outgoing requests. This is used to configure
+      the OpenStack clients via the relation as well as all internal charm http
+      requests.
+    type: string
+    default: ""
+  https-proxy:
+    description: |
+      The HTTPS proxy to use for outgoing requests. This is used to configure
+      the OpenStack clients via the relation as well as all internal charm http
+      requests.
+    type: string
+    default: ""
+  no-proxy:
+    description: |
+      A comma-separated list of hosts and cidrs that excluded from proxying.
+      This is used to configure the OpenStack clients via the relation as well
+      as all internal charm http requests.
+    type: string
+    default: ""
+  proxy-source:
+    description: |
+      The source of the proxy configuration. This is used to configure the
+      OpenStack clients via the relation as well as all internal charm http
+      requests.
+
+      * As "charm", use the proxy settings from the configuration options above.
+      * As "model", use the proxy settings from the model configuration
+
+      (See https://documentation.ubuntu.com/juju/latest/reference/juju-cli/list-of-juju-cli-commands/model-config/).
+
+      Valid values are: "charm" or "model". The default is "charm".
+    type: string
+    default: "charm"

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -174,9 +174,9 @@ options:
       using juju's model-config juju-*-proxy settings.
       (See https://documentation.ubuntu.com/juju/latest/reference/juju-cli/list-of-juju-cli-commands/model-config/).
 
-      Choices are "", "openstack-client", or "subordinates" or any combination
+      Choices are "", "openstack-client", or "integrations" or any combination
 
       * "openstack-client", the local openstack-client application will be proxied
-      * "subordinates", the proxy information will be passed to subordinates of this primary
+      * "integrations", the proxy information will be passed to requirers of the openstack-integrators interface
     type: string
     default: ""

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -168,7 +168,7 @@ options:
       (no floating IP) by default.
     type: boolean
     default: false
-  juju-model-proxy-enable:
+  web-proxy-enable:
     type: boolean
     description: |
       Whether the applications managed by this charm should be

--- a/src/lib/charms/layer/openstack.py
+++ b/src/lib/charms/layer/openstack.py
@@ -27,7 +27,7 @@ from charms.layer import status
 
 
 CACHED_LB_PREFIX = "created_lbs"
-ENDPOINT_TIMEOUT = 30.0 # seconds
+ENDPOINT_TIMEOUT = 30.0  # seconds
 
 # When debugging hooks, for some reason HOME is set to /home/ubuntu, whereas
 # during normal hook execution, it's /root. Set it here to be consistent.

--- a/src/lib/charms/layer/openstack.py
+++ b/src/lib/charms/layer/openstack.py
@@ -17,7 +17,7 @@ from urllib.request import urlopen
 from urllib.parse import urlparse
 from urllib.error import HTTPError
 
-import jmodelproxylib
+import charms.proxylib
 import yaml
 
 from charmhelpers.core import hookenv
@@ -352,8 +352,8 @@ def openstack_proxied(env: Env) -> Generator[Env, None, None]:
         A dictionary with the updated environment variables.
     """
     config = hookenv.config()
-    enabled = bool(config.get("juju-model-proxy-enable"))
-    with jmodelproxylib.environ(env, enabled=enabled) as proxy_env:
+    enabled = bool(config.get("web-proxy-enable"))
+    with charms.proxylib.environ(env, enabled=enabled) as proxy_env:
         if err := proxy_env.error:
             log_err("Error while getting proxy settings: {}", err)
             status.blocked(err)

--- a/src/lib/charms/layer/openstack.py
+++ b/src/lib/charms/layer/openstack.py
@@ -346,7 +346,7 @@ def _valid_url(url: str) -> bool:
 
 class ProxyApplication(Enum):
     OPENSTACK_CLIENT = "openstack-client"
-    SUBORDINATES = "subordinates"
+    INTEGRATIONS = "integrations"
 
     @classmethod
     def from_string(cls, source: str) -> set["ProxyApplication"]:
@@ -365,7 +365,7 @@ def current_proxy_settings() -> dict[ProxyApplication, dict[str, str]]:
 
     proxy_by, src = {
         ProxyApplication.OPENSTACK_CLIENT: {},
-        ProxyApplication.SUBORDINATES: {},
+        ProxyApplication.INTEGRATIONS: {},
     }, os.environ
     for app in proxied:
         settings = {

--- a/src/lib/charms/layer/openstack.py
+++ b/src/lib/charms/layer/openstack.py
@@ -12,13 +12,12 @@ from ipaddress import ip_address, ip_network
 from pathlib import Path
 from time import sleep
 from traceback import format_exc
-from typing import Generator, Optional
+from typing import Generator
 from urllib.request import urlopen
 from urllib.parse import urlparse
 from urllib.error import HTTPError
 
 import jmodelproxylib
-import jmodelproxylib.errors
 import yaml
 
 from charmhelpers.core import hookenv
@@ -36,6 +35,7 @@ os.environ["HOME"] = "/root"
 CA_CERT_FILE = Path("/var/snap/openstackclients/common/ca.crt")
 MODEL_UUID = os.environ["JUJU_MODEL_UUID"]
 MODEL_SHORT_ID = MODEL_UUID.split("-")[-1]
+Env = dict[str, str] | os._Environ
 
 
 def log(msg, *args):
@@ -328,41 +328,6 @@ def get_creds_and_reformat():
 
 def _load_creds():
     return kv().get("charm.openstack.full-creds")
-
-
-class ProxyUrlError(Exception):
-    """Custom exception for invalid proxy URLs."""
-
-    pass
-
-
-def _validate_proxy_url(url: Optional[str]) -> None:
-    """Check if the given URL is valid for use as a proxy.
-
-    Args:
-        url (str): The URL to validate.
-
-    Raises:
-        ProxyUrlError: If the URL is malformed or does not
-                       conform to expected proxy URL formats.
-    """
-    try:
-        parsed = urlparse(url)
-        parsed.port
-    except ValueError as e:
-        # urlparse can raise ValueError if the URL is malformed
-        raise ProxyUrlError(f"Invalid proxy URL: {url=}. {e.args}.") from e
-    if parsed.scheme not in ("http", "https"):
-        raise ProxyUrlError(
-            f"Invalid proxy URL: {url=}. Only 'http' and 'https' schemes are supported."
-        )
-    if not parsed.hostname and not parsed.netloc:
-        raise ProxyUrlError(
-            f"Invalid proxy URL: {url=}. It must include a valid hostname or netloc."
-        )
-
-
-Env = dict[str, str] | os._Environ
 
 
 @lru_cache(maxsize=1)

--- a/src/lib/charms/layer/openstack.py
+++ b/src/lib/charms/layer/openstack.py
@@ -346,7 +346,7 @@ def _valid_url(url: str) -> bool:
 
 class ProxyApplication(Enum):
     OPENSTACK_CLIENT = "openstack-client"
-    INTEGRATIONS = "integrations"
+    CLIENTS = "clients"
 
     @classmethod
     def from_string(cls, source: str) -> set["ProxyApplication"]:
@@ -365,7 +365,7 @@ def current_proxy_settings() -> dict[ProxyApplication, dict[str, str]]:
 
     proxy_by, src = {
         ProxyApplication.OPENSTACK_CLIENT: {},
-        ProxyApplication.INTEGRATIONS: {},
+        ProxyApplication.CLIENTS: {},
     }, os.environ
     for app in proxied:
         settings = {

--- a/src/reactive/openstack.py
+++ b/src/reactive/openstack.py
@@ -336,7 +336,7 @@ def manage_loadbalancers_via_lb_consumers():
                 request.name, members, lb_port, _lb_algo(request), "lb-consumers"
             )
             response.address = lb.fip or lb.address
-            response.error = ""
+            response.error = None
             response.error_message = ""
         except layer.openstack.OpenStackError as e:
             response.error = response.error_types.provider_error

--- a/src/reactive/openstack.py
+++ b/src/reactive/openstack.py
@@ -56,7 +56,7 @@ def update_creds():
     "config.changed.http-proxy",
     "config.changed.https-proxy",
     "config.changed.no-proxy",
-    "config.changed.model-proxy-enable",
+    "config.changed.juju-model-proxy-enable",
 )
 def update_proxy():
     clear_flag("charm.openstack.proxy.set")
@@ -84,7 +84,7 @@ def pre_series_upgrade():
 
 @when_not("charm.openstack.proxy.set")
 def analyze_proxy():
-    settings, updated = layer.openstack.current_proxy_settings(), False
+    settings, updated = layer.openstack.cached_openstack_proxied(), False
 
     clients = endpoint_from_name("clients")
     for request in clients.all_requests:
@@ -144,7 +144,7 @@ def handle_requests():
         layer.status.blocked(f"Invalid value for config {manage_security_groups=}")
         return
 
-    settings = layer.openstack.current_proxy_settings()
+    settings = layer.openstack.cached_openstack_proxied()
 
     creds_changed = is_flag_set("charm.openstack.creds.changed")
     proxy_changed = is_flag_set("charm.openstack.proxy.changed")

--- a/src/reactive/openstack.py
+++ b/src/reactive/openstack.py
@@ -336,6 +336,8 @@ def manage_loadbalancers_via_lb_consumers():
                 request.name, members, lb_port, _lb_algo(request), "lb-consumers"
             )
             response.address = lb.fip or lb.address
+            response.error = ""
+            response.error_message = ""
         except layer.openstack.OpenStackError as e:
             response.error = response.error_types.provider_error
             response.error_message = str(e)

--- a/src/reactive/openstack.py
+++ b/src/reactive/openstack.py
@@ -85,7 +85,7 @@ def pre_series_upgrade():
 @when_not("charm.openstack.proxy.set")
 def analyze_proxy():
     proxy, updated = layer.openstack.current_proxy_settings(), False
-    settings = proxy[layer.openstack.ProxiedApplication.SUBORDINATES]
+    settings = proxy[layer.openstack.ProxiedApplication.INTEGRATIONS]
     if not settings:
         return
 
@@ -94,7 +94,7 @@ def analyze_proxy():
         if request.proxy_config != settings:
             updated = True
     if updated:
-        layer.status.maintenance("Subordinate proxy settings changed")
+        layer.status.maintenance("Integrations proxy settings changed")
         set_flag("charm.openstack.proxy.changed")
 
     set_flag("charm.openstack.proxy.set")
@@ -148,7 +148,7 @@ def handle_requests():
         return
 
     proxy = layer.openstack.current_proxy_settings()
-    settings = proxy[layer.openstack.ProxiedApplication.SUBORDINATES]
+    settings = proxy[layer.openstack.ProxiedApplication.INTEGRATIONS]
 
     creds_changed = is_flag_set("charm.openstack.creds.changed")
     proxy_changed = is_flag_set("charm.openstack.proxy.changed")

--- a/src/reactive/openstack.py
+++ b/src/reactive/openstack.py
@@ -147,8 +147,8 @@ def handle_requests():
         layer.status.blocked(f"Invalid value for config {manage_security_groups=}")
         return
 
-    if not (settings := layer.openstack.current_proxy_settings()):
-        return
+    proxy = layer.openstack.current_proxy_settings()
+    settings = proxy[layer.openstack.ProxiedApplication.SUBORDINATES]
 
     creds_changed = is_flag_set("charm.openstack.creds.changed")
     proxy_changed = is_flag_set("charm.openstack.proxy.changed")

--- a/src/reactive/openstack.py
+++ b/src/reactive/openstack.py
@@ -90,7 +90,7 @@ def analyze_proxy():
 
     clients = endpoint_from_name("clients")
     for request in clients.all_requests:
-        if request.get_proxy_config() != settings:
+        if request.proxy_config != settings:
             updated = True
     if updated:
         layer.status.maintenance("Proxy settings changed")

--- a/src/reactive/openstack.py
+++ b/src/reactive/openstack.py
@@ -56,7 +56,7 @@ def update_creds():
     "config.changed.http-proxy",
     "config.changed.https-proxy",
     "config.changed.no-proxy",
-    "config.changed.proxy-applications",
+    "config.changed.model-proxy-enable",
 )
 def update_proxy():
     clear_flag("charm.openstack.proxy.set")
@@ -84,10 +84,7 @@ def pre_series_upgrade():
 
 @when_not("charm.openstack.proxy.set")
 def analyze_proxy():
-    proxy, updated = layer.openstack.current_proxy_settings(), False
-    settings = proxy[layer.openstack.ProxiedApplication.CLIENTS]
-    if not settings:
-        return
+    settings, updated = layer.openstack.current_proxy_settings(), False
 
     clients = endpoint_from_name("clients")
     for request in clients.all_requests:
@@ -147,8 +144,7 @@ def handle_requests():
         layer.status.blocked(f"Invalid value for config {manage_security_groups=}")
         return
 
-    proxy = layer.openstack.current_proxy_settings()
-    settings = proxy[layer.openstack.ProxiedApplication.INTEGRATIONS]
+    settings = layer.openstack.current_proxy_settings()
 
     creds_changed = is_flag_set("charm.openstack.creds.changed")
     proxy_changed = is_flag_set("charm.openstack.proxy.changed")

--- a/src/reactive/openstack.py
+++ b/src/reactive/openstack.py
@@ -56,7 +56,7 @@ def update_creds():
     "config.changed.http-proxy",
     "config.changed.https-proxy",
     "config.changed.no-proxy",
-    "config.changed.juju-model-proxy-enable",
+    "config.changed.web-proxy-enable",
 )
 def update_proxy():
     clear_flag("charm.openstack.proxy.set")

--- a/src/reactive/openstack.py
+++ b/src/reactive/openstack.py
@@ -85,7 +85,7 @@ def pre_series_upgrade():
 @when_not("charm.openstack.proxy.set")
 def analyze_proxy():
     proxy, updated = layer.openstack.current_proxy_settings(), False
-    settings = proxy[layer.openstack.ProxiedApplication.INTEGRATIONS]
+    settings = proxy[layer.openstack.ProxiedApplication.CLIENTS]
     if not settings:
         return
 
@@ -94,7 +94,7 @@ def analyze_proxy():
         if request.proxy_config != settings:
             updated = True
     if updated:
-        layer.status.maintenance("Integrations proxy settings changed")
+        layer.status.maintenance("Clients proxy settings changed")
         set_flag("charm.openstack.proxy.changed")
 
     set_flag("charm.openstack.proxy.set")

--- a/src/reactive/openstack.py
+++ b/src/reactive/openstack.py
@@ -56,7 +56,7 @@ def update_creds():
     "config.changed.http-proxy",
     "config.changed.https-proxy",
     "config.changed.no-proxy",
-    "config.changed.proxy-source",
+    "config.changed.proxy-applications",
 )
 def update_proxy():
     clear_flag("charm.openstack.proxy.set")
@@ -84,7 +84,8 @@ def pre_series_upgrade():
 
 @when_not("charm.openstack.proxy.set")
 def analyze_proxy():
-    settings, updated = layer.openstack.current_proxy_settings(), False
+    proxy, updated = layer.openstack.current_proxy_settings(), False
+    settings = proxy[layer.openstack.ProxiedApplication.SUBORDINATES]
     if not settings:
         return
 
@@ -93,7 +94,7 @@ def analyze_proxy():
         if request.proxy_config != settings:
             updated = True
     if updated:
-        layer.status.maintenance("Proxy settings changed")
+        layer.status.maintenance("Subordinate proxy settings changed")
         set_flag("charm.openstack.proxy.changed")
 
     set_flag("charm.openstack.proxy.set")

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,6 +1,6 @@
 loadbalancer_interface==1.2.1
 str2bool==1.1
 pbr==6.1.0
-setuptools==70.3.0
+setuptools==77.0.3
 ops==2.20.0
-jmodelproxylib @ git+https://github.com/addyess/jmodelproxylib@main
+charms.proxylib == 0.0.0

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -2,3 +2,4 @@ loadbalancer_interface
 str2bool
 pbr<6.1.1
 setuptools==70.3.0
+jmodelproxylib @ git+https://github.com/addyess/jmodelproxylib@main

--- a/tests/unit/test_openstack_integrator.py
+++ b/tests/unit/test_openstack_integrator.py
@@ -200,7 +200,7 @@ def test_default_subnet(_openstack):
 def test_manage_loadbalancer(mock_lb, mock_subnet):
     lb_method = "ROUND_ROBIN"
     lb_port = "6443"
-    openstack.config = {
+    openstack.hookenv.config.return_value = {
         "lb-subnet": "",
         "lb-floating-network": "fip-network",
         "lb-port": lb_port,
@@ -549,9 +549,9 @@ def test_is_base64():
 
 
 def test_series_upgrade():
-    assert charms.layer.status.blocked.call_count == 0
+    charms.layer.status.blocked.reset_mock()
     reactive.openstack.pre_series_upgrade()
-    assert charms.layer.status.blocked.call_count == 1
+    charms.layer.status.blocked.assert_called_with("Series upgrade in progress")
 
 
 def test_update_credentials(_normalize_creds, _save_creds, log_err):

--- a/tests/unit/test_openstack_integrator.py
+++ b/tests/unit/test_openstack_integrator.py
@@ -221,6 +221,7 @@ def test_run_with_creds(_load_creds):
         },
         check=True,
         stdout=mock.ANY,
+        timeout=30.0,
     )
 
     _load_creds.return_value["endpoint_tls_ca"] = _b64("foo")

--- a/tests/unit/test_openstack_integrator.py
+++ b/tests/unit/test_openstack_integrator.py
@@ -109,7 +109,7 @@ def test_determine_version_by_url(log_err):
 
 def test_cached_openstack_proxied_valid():
     # Test cached_openstack_proxied
-    openstack.hookenv.config.return_value = {"juju-model-proxy-enable": True}
+    openstack.hookenv.config.return_value = {"web-proxy-enable": True}
     openstack.cached_openstack_proxied.cache_clear()
     settings = openstack.cached_openstack_proxied()
     assert isinstance(settings, dict)
@@ -124,7 +124,7 @@ def test_cached_openstack_proxied_valid():
 def test_cached_openstack_proxied_invalid(mock_getenv):
     # Test cached_openstack_proxied
     mock_getenv.override = {"JUJU_CHARM_HTTPS_PROXY": "invalid-url"}
-    openstack.hookenv.config.return_value = {"juju-model-proxy-enable": True}
+    openstack.hookenv.config.return_value = {"web-proxy-enable": True}
     openstack.cached_openstack_proxied.cache_clear()
     settings = openstack.cached_openstack_proxied()
     assert settings == {}
@@ -156,7 +156,7 @@ def test_determine_version_fetch_with_failure(log_err, http_failure):
     )
 
     args = {}, "https://endpoint/", None
-    openstack.hookenv.config.return_value = {"juju-model-proxy-enable": False}
+    openstack.hookenv.config.return_value = {"web-proxy-enable": False}
     assert openstack._determine_version(*args) == "3"
     log_err.assert_not_called()
 
@@ -173,7 +173,7 @@ def _b64(s):
 
 
 def test_run_with_creds(_load_creds):
-    openstack.hookenv.config.return_value = {"juju-model-proxy-enable": True}
+    openstack.hookenv.config.return_value = {"web-proxy-enable": True}
     _load_creds.return_value = {
         "auth_url": "auth_url",
         "region": "region",
@@ -192,7 +192,7 @@ def test_run_with_creds(_load_creds):
         "JUJU_CHARM_NO_PROXY": "",
     }
     with mock.patch(
-        "jmodelproxylib.model.raw",
+        "charms.proxylib.model.raw",
         return_value=proxy_settings,
     ), mock.patch.dict(os.environ, {"PATH": "path"}):
         openstack._run_with_creds("my", "args")

--- a/tests/unit/test_openstack_integrator.py
+++ b/tests/unit/test_openstack_integrator.py
@@ -80,6 +80,26 @@ def test_determine_version_by_url(log_err):
 
 
 @pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://valid-url.com", True),
+        ("http://valid-url.com", True),
+        ("http://valid-url.com:8080", True),
+        ("http://1.2.3.4:8080", True),
+        ("http://[::1]:8080", True),
+        ("http://user:pass@valid-url.com:8080/v1/api", True),
+        ("http://valid-url.com:80808", False),
+        ("ftp://invalid-url.com", False),
+        ("invalid-url", False),
+        ("https://", False),
+        ("", False),
+    ],
+)
+def test_valid_url_cases(url, expected):
+    assert openstack._valid_url(url) == expected
+
+
+@pytest.mark.parametrize(
     "http_failure",
     [
         ValueError("foo"),

--- a/tests/unit/test_openstack_integrator.py
+++ b/tests/unit/test_openstack_integrator.py
@@ -107,36 +107,6 @@ def test_determine_version_by_url(log_err):
     log_err.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "url",
-    [
-        "https://valid-url.com",
-        "http://valid-url.com",
-        "http://valid-url.com:8080",
-        "http://1.2.3.4:8080",
-        "http://[::1]:8080",
-        "http://user:pass@valid-url.com:8080/v1/api",
-    ],
-)
-def test_validate_proxy_url_valid(url):
-    # Test valid URLs
-    openstack._validate_proxy_url(url)
-
-
-@pytest.mark.parametrize(
-    "url,detail",
-    [
-        ("http://", "It must include a valid hostname or netloc."),
-        ("ftp://example.com", "Only 'http' and 'https' schemes are supported"),
-        ("https://example.com:80808", "Port out of range 0-65535"),
-    ],
-)
-def test_validate_proxy_url(url, detail):
-    with pytest.raises(openstack.ProxyUrlError) as ie:
-        openstack._validate_proxy_url(url)
-    ie.match(detail)
-
-
 def test_cached_openstack_proxied_valid():
     # Test cached_openstack_proxied
     openstack.hookenv.config.return_value = {"juju-model-proxy-enable": True}

--- a/tests/unit/test_reactive_openstack.py
+++ b/tests/unit/test_reactive_openstack.py
@@ -8,7 +8,7 @@ from reactive.openstack import analyze_proxy, lb_manage_security_groups
 @mock.patch("reactive.openstack.set_flag")
 def test_analyze_proxy_currently_unset(set_flag, layer, endpoint_from_name):
     # Test with no proxy settings
-    layer.openstack.current_proxy_settings.return_value = {}
+    layer.openstack.cached_openstack_proxied.return_value = {}
     client_request = mock.MagicMock()
     client_request.proxy_config = {}
     client_endpoint = endpoint_from_name.return_value
@@ -34,7 +34,7 @@ def test_analyze_proxy_matched_settings(set_flag, layer, endpoint_from_name):
     client_request.proxy_config = settings
     client_endpoint = endpoint_from_name.return_value
     client_endpoint.all_requests = [client_request]
-    layer.openstack.current_proxy_settings.return_value = settings
+    layer.openstack.cached_openstack_proxied.return_value = settings
     analyze_proxy()
     endpoint_from_name.assert_called_once_with("clients")
     layer.status.maintenance.assert_not_called()
@@ -55,7 +55,7 @@ def test_analyze_proxy_unmatched_settings(set_flag, layer, endpoint_from_name):
     client_request.proxy_config = {**settings, "NO_PROXY": ""}
     client_endpoint = endpoint_from_name.return_value
     client_endpoint.all_requests = [client_request]
-    layer.openstack.current_proxy_settings.return_value = settings
+    layer.openstack.cached_openstack_proxied.return_value = settings
     analyze_proxy()
     layer.status.maintenance.assert_called_once_with("Clients proxy settings changed")
     endpoint_from_name.assert_called_once_with("clients")

--- a/tests/unit/test_reactive_openstack.py
+++ b/tests/unit/test_reactive_openstack.py
@@ -5,13 +5,18 @@ from reactive.openstack import analyze_proxy, lb_manage_security_groups
 
 @mock.patch("reactive.openstack.endpoint_from_name")
 @mock.patch("reactive.openstack.layer")
-def test_analyze_proxy_currently_unset(layer, endpoint_from_name):
+@mock.patch("reactive.openstack.set_flag")
+def test_analyze_proxy_currently_unset(set_flag, layer, endpoint_from_name):
     # Test with no proxy settings
-    layer.openstack.current_proxy_settings.return_value = {
-        layer.openstack.ProxiedApplication.CLIENTS: {}
-    }
+    layer.openstack.current_proxy_settings.return_value = {}
+    client_request = mock.MagicMock()
+    client_request.proxy_config = {}
+    client_endpoint = endpoint_from_name.return_value
+    client_endpoint.all_requests = []
     analyze_proxy()
-    endpoint_from_name.assert_not_called()
+    endpoint_from_name.assert_called_once_with("clients")
+    layer.status.maintenance.assert_not_called()
+    set_flag.assert_called_once_with("charm.openstack.proxy.set")
 
 
 @mock.patch("reactive.openstack.endpoint_from_name")
@@ -24,13 +29,12 @@ def test_analyze_proxy_matched_settings(set_flag, layer, endpoint_from_name):
         "HTTPS_PROXY": "https://proxy.example.com:8080",
         "NO_PROXY": "127.0.0.1,localhost,::1",
     }
+    settings.update({k.lower(): v for k, v in settings.items()})
     client_request = mock.MagicMock()
     client_request.proxy_config = settings
     client_endpoint = endpoint_from_name.return_value
     client_endpoint.all_requests = [client_request]
-    layer.openstack.current_proxy_settings.return_value = {
-        layer.openstack.ProxiedApplication.CLIENTS: settings
-    }
+    layer.openstack.current_proxy_settings.return_value = settings
     analyze_proxy()
     endpoint_from_name.assert_called_once_with("clients")
     layer.status.maintenance.assert_not_called()
@@ -51,9 +55,7 @@ def test_analyze_proxy_unmatched_settings(set_flag, layer, endpoint_from_name):
     client_request.proxy_config = {**settings, "NO_PROXY": ""}
     client_endpoint = endpoint_from_name.return_value
     client_endpoint.all_requests = [client_request]
-    layer.openstack.current_proxy_settings.return_value = {
-        layer.openstack.ProxiedApplication.CLIENTS: settings
-    }
+    layer.openstack.current_proxy_settings.return_value = settings
     analyze_proxy()
     layer.status.maintenance.assert_called_once_with("Clients proxy settings changed")
     endpoint_from_name.assert_called_once_with("clients")

--- a/tests/unit/test_reactive_openstack.py
+++ b/tests/unit/test_reactive_openstack.py
@@ -8,7 +8,7 @@ from reactive.openstack import analyze_proxy, lb_manage_security_groups
 def test_analyze_proxy_currently_unset(layer, endpoint_from_name):
     # Test with no proxy settings
     layer.openstack.current_proxy_settings.return_value = {
-        layer.openstack.ProxiedApplication.SUBORDINATES: {}
+        layer.openstack.ProxiedApplication.INTEGRATIONS: {}
     }
     analyze_proxy()
     endpoint_from_name.assert_not_called()
@@ -29,7 +29,7 @@ def test_analyze_proxy_matched_settings(set_flag, layer, endpoint_from_name):
     client_endpoint = endpoint_from_name.return_value
     client_endpoint.all_requests = [client_request]
     layer.openstack.current_proxy_settings.return_value = {
-        layer.openstack.ProxiedApplication.SUBORDINATES: settings
+        layer.openstack.ProxiedApplication.INTEGRATIONS: settings
     }
     analyze_proxy()
     endpoint_from_name.assert_called_once_with("clients")
@@ -52,11 +52,11 @@ def test_analyze_proxy_unmatched_settings(set_flag, layer, endpoint_from_name):
     client_endpoint = endpoint_from_name.return_value
     client_endpoint.all_requests = [client_request]
     layer.openstack.current_proxy_settings.return_value = {
-        layer.openstack.ProxiedApplication.SUBORDINATES: settings
+        layer.openstack.ProxiedApplication.INTEGRATIONS: settings
     }
     analyze_proxy()
     layer.status.maintenance.assert_called_once_with(
-        "Subordinate proxy settings changed"
+        "Integrations proxy settings changed"
     )
     endpoint_from_name.assert_called_once_with("clients")
     set_flag.assert_any_call("charm.openstack.proxy.changed")

--- a/tests/unit/test_reactive_openstack.py
+++ b/tests/unit/test_reactive_openstack.py
@@ -1,6 +1,11 @@
+import enum
 import pytest
 import unittest.mock as mock
-from reactive.openstack import analyze_proxy, lb_manage_security_groups
+import reactive.openstack as charm
+import charms.reactive
+
+from charmhelpers.core import hookenv
+from charms.layer.openstack import OpenStackError
 
 
 @mock.patch("reactive.openstack.endpoint_from_name")
@@ -13,7 +18,7 @@ def test_analyze_proxy_currently_unset(set_flag, layer, endpoint_from_name):
     client_request.proxy_config = {}
     client_endpoint = endpoint_from_name.return_value
     client_endpoint.all_requests = []
-    analyze_proxy()
+    charm.analyze_proxy()
     endpoint_from_name.assert_called_once_with("clients")
     layer.status.maintenance.assert_not_called()
     set_flag.assert_called_once_with("charm.openstack.proxy.set")
@@ -35,7 +40,7 @@ def test_analyze_proxy_matched_settings(set_flag, layer, endpoint_from_name):
     client_endpoint = endpoint_from_name.return_value
     client_endpoint.all_requests = [client_request]
     layer.openstack.cached_openstack_proxied.return_value = settings
-    analyze_proxy()
+    charm.analyze_proxy()
     endpoint_from_name.assert_called_once_with("clients")
     layer.status.maintenance.assert_not_called()
     set_flag.assert_called_once_with("charm.openstack.proxy.set")
@@ -56,7 +61,7 @@ def test_analyze_proxy_unmatched_settings(set_flag, layer, endpoint_from_name):
     client_endpoint = endpoint_from_name.return_value
     client_endpoint.all_requests = [client_request]
     layer.openstack.cached_openstack_proxied.return_value = settings
-    analyze_proxy()
+    charm.analyze_proxy()
     layer.status.maintenance.assert_called_once_with("Clients proxy settings changed")
     endpoint_from_name.assert_called_once_with("clients")
     set_flag.assert_any_call("charm.openstack.proxy.changed")
@@ -74,4 +79,113 @@ def test_analyze_proxy_unmatched_settings(set_flag, layer, endpoint_from_name):
 )
 def test_lb_secgroup_valid(value, expected):
     config = {"manage-security-groups": value}
-    assert lb_manage_security_groups(config) is expected
+    assert charm.lb_manage_security_groups(config) is expected
+
+
+def test_validate_loadbalancer_request_no_errors():
+    request = mock.MagicMock()
+    request.protocol.value = "tcp"
+    request.algorithm = "ROUND_ROBIN"
+    request.tls_termination = False
+    request.health_checks = []
+    request.port_mapping = {80: 8080}
+    request.backends = None
+    hookenv.config.return_value = {
+        "lb-port": 443,
+    }
+    response = charm._validate_loadbalancer_request(request)
+    assert response is request.response
+    assert response.error_fields == {}
+
+
+class TestProtocol(enum.Enum):
+    http = "http"
+
+
+@pytest.mark.parametrize(
+    "field, value, error_msg",
+    [
+        ("public", None, "Only support public loadbalancers"),
+        (
+            "protocol",
+            TestProtocol.http,
+            "Must be one of: udp, tcp",
+        ),
+        (
+            "algorithm",
+            "INVALID",
+            "Must be one of: ROUND_ROBIN, LEAST_CONNECTIONS, SOURCE_IP",
+        ),
+        ("tls_termination", True, "Not yet supported"),
+        (
+            "health_checks",
+            [mock.MagicMock(protocol=mock.MagicMock(value="ftp"))],
+            {
+                "hc[0].path": "Only valid with http(s) protocol",
+                "hc[0].protocol": "Must be one of: udp, tcp",
+            },
+        ),
+        (
+            "backends",
+            ["invalid_ip"],
+            {
+                "port_mapping": "Invalid port mapping, lb_port=0, remote_port=None",
+            },
+        ),
+    ],
+)
+def test_validate_loadbalancer_request_error(field, value, error_msg):
+    request = mock.MagicMock()
+    request.protocol.value = "tcp"
+    request.algorithm = "ROUND_ROBIN"
+    request.tls_termination = False
+    request.health_checks = []
+    request.port_mapping = {}
+    request.backends = None
+    hookenv.config.return_value = {
+        "lb-port": 0,
+    }
+
+    setattr(request, field, value)
+    response = charm._validate_loadbalancer_request(request)
+    assert response is request.response
+    if isinstance(error_msg, dict):
+        assert response.error_fields == error_msg
+    else:
+        assert response.error_fields == {field: error_msg}
+
+
+@mock.patch.object(charm, "_validate_loadbalancer_request")
+@mock.patch("charms.layer.openstack.manage_loadbalancer")
+@pytest.mark.parametrize("failure_message", ["", "Failed to allocate floating IP"])
+def test_manage_loadbalancer_via_lb_consumers(
+    manage_loadbalancer, validate, failure_message
+):
+    lb_consumers = charms.reactive.relations.endpoint_from_name.return_value
+    lb_consumers.send_response.reset_mock()
+    request = mock.MagicMock(name="req-1")
+    response = request.response
+    lb_consumers.new_requests = [request]
+
+    validate.side_effect = lambda req: req.response
+    response.error_fields = {}
+    request.port_mapping = {443: 6443}
+    request.backends = ["1.2.3.4"]
+    request.algorithm = "ROUND_ROBIN"
+
+    if failure_message:
+        manage_loadbalancer.side_effect = OpenStackError(failure_message)
+        charm.manage_loadbalancers_via_lb_consumers()
+        validate.assert_called_once_with(request)
+        assert response.error == response.error_types.provider_error
+        assert response.error_message == failure_message
+        lb_consumers.send_response.assert_called_once_with(request)
+
+    else:
+        lb = manage_loadbalancer.return_value
+        charm.manage_loadbalancers_via_lb_consumers()
+        validate.assert_called_once_with(request)
+        assert response.address == lb.fip
+        assert response.error is None
+        assert response.error_message == ""
+        lb_consumers.send_response.assert_called_once_with(request)

--- a/tests/unit/test_reactive_openstack.py
+++ b/tests/unit/test_reactive_openstack.py
@@ -8,7 +8,7 @@ from reactive.openstack import analyze_proxy, lb_manage_security_groups
 def test_analyze_proxy_currently_unset(layer, endpoint_from_name):
     # Test with no proxy settings
     layer.openstack.current_proxy_settings.return_value = {
-        layer.openstack.ProxiedApplication.INTEGRATIONS: {}
+        layer.openstack.ProxiedApplication.CLIENTS: {}
     }
     analyze_proxy()
     endpoint_from_name.assert_not_called()
@@ -29,7 +29,7 @@ def test_analyze_proxy_matched_settings(set_flag, layer, endpoint_from_name):
     client_endpoint = endpoint_from_name.return_value
     client_endpoint.all_requests = [client_request]
     layer.openstack.current_proxy_settings.return_value = {
-        layer.openstack.ProxiedApplication.INTEGRATIONS: settings
+        layer.openstack.ProxiedApplication.CLIENTS: settings
     }
     analyze_proxy()
     endpoint_from_name.assert_called_once_with("clients")
@@ -52,12 +52,10 @@ def test_analyze_proxy_unmatched_settings(set_flag, layer, endpoint_from_name):
     client_endpoint = endpoint_from_name.return_value
     client_endpoint.all_requests = [client_request]
     layer.openstack.current_proxy_settings.return_value = {
-        layer.openstack.ProxiedApplication.INTEGRATIONS: settings
+        layer.openstack.ProxiedApplication.CLIENTS: settings
     }
     analyze_proxy()
-    layer.status.maintenance.assert_called_once_with(
-        "Integrations proxy settings changed"
-    )
+    layer.status.maintenance.assert_called_once_with("Clients proxy settings changed")
     endpoint_from_name.assert_called_once_with("clients")
     set_flag.assert_any_call("charm.openstack.proxy.changed")
     set_flag.assert_any_call("charm.openstack.proxy.set")

--- a/tests/unit/test_reactive_openstack.py
+++ b/tests/unit/test_reactive_openstack.py
@@ -1,6 +1,58 @@
 import pytest
+import unittest.mock as mock
+from reactive.openstack import analyze_proxy, lb_manage_security_groups
 
-from reactive.openstack import lb_manage_security_groups
+
+@mock.patch("reactive.openstack.endpoint_from_name")
+@mock.patch("reactive.openstack.layer")
+def test_analyze_proxy_currently_unset(layer, endpoint_from_name):
+    # Test with no proxy settings
+    layer.openstack.current_proxy_settings.return_value = {}
+    analyze_proxy()
+    endpoint_from_name.assert_not_called()
+
+
+@mock.patch("reactive.openstack.endpoint_from_name")
+@mock.patch("reactive.openstack.layer")
+@mock.patch("reactive.openstack.set_flag")
+def test_analyze_proxy_matched_settings(set_flag, layer, endpoint_from_name):
+    # Test with matching proxy settings
+    settings = {
+        "HTTP_PROXY": "http://proxy.example.com:8080",
+        "HTTPS_PROXY": "https://proxy.example.com:8080",
+        "NO_PROXY": "127.0.0.1,localhost,::1",
+    }
+    client_request = mock.MagicMock()
+    client_request.proxy_config = settings
+    client_endpoint = endpoint_from_name.return_value
+    client_endpoint.all_requests = [client_request]
+    layer.openstack.current_proxy_settings.return_value = settings
+    analyze_proxy()
+    endpoint_from_name.assert_called_once_with("clients")
+    layer.status.maintenance.assert_not_called()
+    set_flag.assert_called_once_with("charm.openstack.proxy.set")
+
+
+@mock.patch("reactive.openstack.endpoint_from_name")
+@mock.patch("reactive.openstack.layer")
+@mock.patch("reactive.openstack.set_flag")
+def test_analyze_proxy_unmatched_settings(set_flag, layer, endpoint_from_name):
+    # Test with updated proxy settings
+    settings = {
+        "HTTP_PROXY": "http://proxy.example.com:8080",
+        "HTTPS_PROXY": "https://proxy.example.com:8080",
+        "NO_PROXY": "127.0.0.1,localhost,::1",
+    }
+    client_request = mock.MagicMock()
+    client_request.proxy_config = {**settings, "NO_PROXY": ""}
+    client_endpoint = endpoint_from_name.return_value
+    client_endpoint.all_requests = [client_request]
+    layer.openstack.current_proxy_settings.return_value = settings
+    analyze_proxy()
+    layer.status.maintenance.assert_called_once_with("Proxy settings changed")
+    endpoint_from_name.assert_called_once_with("clients")
+    set_flag.assert_any_call("charm.openstack.proxy.changed")
+    set_flag.assert_any_call("charm.openstack.proxy.set")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_reactive_openstack.py
+++ b/tests/unit/test_reactive_openstack.py
@@ -7,7 +7,9 @@ from reactive.openstack import analyze_proxy, lb_manage_security_groups
 @mock.patch("reactive.openstack.layer")
 def test_analyze_proxy_currently_unset(layer, endpoint_from_name):
     # Test with no proxy settings
-    layer.openstack.current_proxy_settings.return_value = {}
+    layer.openstack.current_proxy_settings.return_value = {
+        layer.openstack.ProxiedApplication.SUBORDINATES: {}
+    }
     analyze_proxy()
     endpoint_from_name.assert_not_called()
 
@@ -26,7 +28,9 @@ def test_analyze_proxy_matched_settings(set_flag, layer, endpoint_from_name):
     client_request.proxy_config = settings
     client_endpoint = endpoint_from_name.return_value
     client_endpoint.all_requests = [client_request]
-    layer.openstack.current_proxy_settings.return_value = settings
+    layer.openstack.current_proxy_settings.return_value = {
+        layer.openstack.ProxiedApplication.SUBORDINATES: settings
+    }
     analyze_proxy()
     endpoint_from_name.assert_called_once_with("clients")
     layer.status.maintenance.assert_not_called()
@@ -47,9 +51,13 @@ def test_analyze_proxy_unmatched_settings(set_flag, layer, endpoint_from_name):
     client_request.proxy_config = {**settings, "NO_PROXY": ""}
     client_endpoint = endpoint_from_name.return_value
     client_endpoint.all_requests = [client_request]
-    layer.openstack.current_proxy_settings.return_value = settings
+    layer.openstack.current_proxy_settings.return_value = {
+        layer.openstack.ProxiedApplication.SUBORDINATES: settings
+    }
     analyze_proxy()
-    layer.status.maintenance.assert_called_once_with("Proxy settings changed")
+    layer.status.maintenance.assert_called_once_with(
+        "Subordinate proxy settings changed"
+    )
     endpoint_from_name.assert_called_once_with("clients")
     set_flag.assert_any_call("charm.openstack.proxy.changed")
     set_flag.assert_any_call("charm.openstack.proxy.set")


### PR DESCRIPTION
Resolves: [LP#2104884](https://bugs.launchpad.net/charm-openstack-integrator/+bug/2104884)

### Overview
1) Contact O7K endpoints through the http proxy settings determined by the `juju-model-proxy-enable` config

### Details
this dictionary will be filled by the `juju model-config` with the following env variables: 
* `juju-http-proxy` --> `HTTP_PROXY`
* `juju-https-proxy` --> `HTTPS_PROXY`
* `juju-no-proxy` --> `NO_PROXY`
* `juju-http-proxy` --> `http_proxy`
* `juju-http-proxy` --> `https_proxy`
* `juju-http-proxy` --> `no_proxy`

The storage-manifest ensures that both `no_proxy` and `NO_PROXY` have specific hostname carve-outs for in cluster domains

### Depends on
* https://github.com/canonical/interface-openstack-integration/pull/19