### PR TITLE
[LP#2110221] Config change and Creds changes validates LB Requests

### DIFF
--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,7 +1,4 @@
-loadbalancer_interface==1.2.1
+loadbalancer_interface
+str2bool
 pbr<6.1.1
-setuptools==80.3.1
-str2bool==1.1
-opentelemetry_api==1.32.0
-hatchling==1.27.0
-calver==2025.4.17
+setuptools==70.3.0

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,4 +1,7 @@
-loadbalancer_interface
-str2bool
+loadbalancer_interface==1.2.1
 pbr<6.1.1
-setuptools==70.3.0
+setuptools==80.3.1
+str2bool==1.1
+opentelemetry_api==1.32.0
+hatchling==1.27.0
+calver==2025.4.17


### PR DESCRIPTION
Addresses Bug [LP#2110221](https://bugs.launchpad.net/charm-openstack-integrator/+bug/2110221)

Changes to Charm config or Credential changes should trigger a validation refresh.  This is particularly useful when the integrator responds to a request with a failure.  There's nothing the user can do in this situation after fixing the failure conditions other than remove/re-add the relation.  It would be better to let the user change the config to refresh all the existing `lb_consumer` requests. 

