### PR TITLE
Pin back ops to the last release without opentelemetry

### DIFF
--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,4 +1,5 @@
-loadbalancer_interface
-str2bool
-pbr<6.1.1
+loadbalancer_interface==1.2.1
+str2bool==1.1
+pbr==6.1.0
 setuptools==70.3.0
+ops==2.20.0


### PR DESCRIPTION
`ops==2.21.0` now depends on opentelemetry-api and importlib-metadata
* https://github.com/canonical/operator/blob/2.21.0/pyproject.toml

This charm has no need for these additions, and should pin to a time before they were necessary to be in the wheelhouse