### PR TITLE
[LP#2110255] Request LB creation based on the requested protocol

### DIFF
--- a/src/lib/charms/layer/openstack.py
+++ b/src/lib/charms/layer/openstack.py
@@ -1,11 +1,13 @@
 import binascii
 import contextlib
+import dataclasses
 import enum
 import json
 import re
 import os
 import subprocess
 import tempfile
+from loadbalancer_interface.schemas.v1 import HealthCheck
 from base64 import b64decode, b64encode
 from contextlib import contextmanager
 from functools import lru_cache
@@ -29,16 +31,28 @@ from charms.layer import status
 CACHED_LB_PREFIX = "created_lbs"
 ENDPOINT_TIMEOUT = 30.0  # seconds
 DEFAULT_PROTOCOL = "HTTPS"
+DEFAULT_HC_DELAY = 5
 
 
 class HC_TYPE(enum.Enum):
-    TLS_HELLO = "TLS-HELLO"
     HTTP = "HTTP"
+    HTTPS = "HTTPS"
     TCP = "TCP"
-    UDP_CONNECT = "UDP-CONNECT"
+    TLS_HELLO = "TLS-HELLO"  # Fallback for HTTP(S) without path
+    UDP_CONNECT = "UDP-CONNECT"  # Mapping for "udp" health check
+    # The following are supported by openstack, but not valid in the relation
+    # PING = "PING"
+    # SCTP = "SCTP"
 
 
-DEFAULT_HC_TYPE = HC_TYPE.TLS_HELLO
+"""
+For backwards compatibility
+Maintain the previous fallback protocol TLS-HELLO
+"""
+DEFAULT_HC_REQ = HealthCheck()
+DEFAULT_HC_REQ.protocol = HC_TYPE.TLS_HELLO.value
+DEFAULT_HC_REQ.interval = 10
+DEFAULT_HC_REQ.retries = 4
 
 # When debugging hooks, for some reason HOME is set to /home/ubuntu, whereas
 # during normal hook execution, it's /root. Set it here to be consistent.
@@ -58,24 +72,99 @@ def log_err(msg, *args):
     hookenv.log(msg.format(*args), hookenv.ERROR)
 
 
-def _healthmonitor_type_by_proto(provider: str, proto: str) -> HC_TYPE:
-    proto = proto.upper()
-    provider = provider.lower()
+@dataclasses.dataclass
+class HCOpts:
+    # BASED on the CreateOpts from gophercloud openstack.loadbalancer.v2.monitors
+    # https://pkg.go.dev/github.com/gophercloud/gophercloud@v1.14.1/openstack/loadbalancer/v2/monitors#CreateOpts
+    name: str
 
-    if not provider:
-        return DEFAULT_HC_TYPE
+    # The type of probe, which is PING, TCP, HTTP, or HTTPS, that is
+    # sent by the load balancer to verify the member state.
+    type: str
 
-    if provider == "ovn":
-        # OVN can only handle TCP / UDP checks
-        return HC_TYPE.TCP if proto != "UDP" else HC_TYPE.UDP_CONNECT
+    # The time, in seconds, between sending probes to members.
+    delay: int
 
-    if proto == "HTTPS":
-        return DEFAULT_HC_TYPE
+    # Maximum number of seconds for a Monitor to wait for a ping reply
+    # before it times out. The value must be less than the delay value.
+    timeout: int
 
-    if proto == "TERMINATED_HTTPS":
-        return HC_TYPE.HTTP
+    # Number of permissible ping failures before changing the member's
+    # status to INACTIVE. Must be a number between 1 and 10.
+    max_retries: int
 
-    return HC_TYPE.TCP
+    # Number of permissible ping failures before changing the member's
+    # status to ERROR. Must be a number between 1 and 10.
+    max_retries_down: Optional[int] = None
+
+    # URI path that will be accessed if Monitor type is HTTP or HTTPS.
+    url_path: Optional[str] = None
+
+    # The HTTP method used for requests by the Monitor. If this attribute
+    # is not specified, it defaults to "GET". Required for HTTP(S) types.
+    http_method: Optional[str] = None
+
+    # Expected HTTP codes for a passing HTTP(S) Monitor. You can either specify
+    # a single status like "200", a range like "200-202", or a combination like
+    # "200-202, 401".
+    expected_codes: Optional[str] = None
+
+
+def _health_monitor_name(index: int, name: str) -> str:
+    return "{}-{}".format(name, index) if index > 0 else name
+
+
+def _health_monitor_create_opts(
+    lb_info: dict, req: HealthCheck, index: int, proto: str
+) -> HCOpts:
+    """
+    Create health monitor options from the given request.
+
+    Based loosely on the impl for Kubernetes Services of Loadbalancer type in openstack
+    https://github.com/kubernetes/cloud-provider-openstack/blob/a031201ff26f3df433192b91df2be0e7d50acb70/pkg/openstack/loadbalancer.go#L846
+
+    Args:
+        lb_info: The load balancer information dictionary.
+        req: The health check request from the loadbalancer-consumer relation.
+        index: The index of the health check in the list.
+        proto: The protocol of the load balancer pool.
+    """
+    provider = lb_info.get("provider") or ""
+    opts = HCOpts(
+        name=_health_monitor_name(index, lb_info["name"]),
+        type=proto.upper(),
+        delay=DEFAULT_HC_DELAY,
+        timeout=req.interval,
+        max_retries=req.retries,
+    )
+    if proto == "UDP":
+        opts.type = HC_TYPE.UDP_CONNECT.value
+    elif _can_use_http_monitor(req, provider):
+        # Can use HTTP(S) monitor
+        # if the path is in the request, use HTTP(S) monitor
+        if req.path:
+            opts.type = req.protocol.value.upper()
+            opts.url_path = req.path
+            opts.http_method = "GET"
+            opts.expected_codes = "200-499"  # accept any 2xx, 3xx, 4xx as healthy
+        else:
+            # No path provided, fallback to TLS-HELLO for HTTPS or HTTP
+            opts.type = HC_TYPE.TLS_HELLO.value
+    elif req.protocol.value.upper() in [HC_TYPE.HTTP.value, HC_TYPE.HTTPS.value]:
+        # Relation requests HTTP(s) but cannot use HTTP(S) monitor
+        # Fallback to TCP
+        opts.type = HC_TYPE.TCP.value
+
+    return opts
+
+
+def _can_use_http_monitor(req: HealthCheck, provider: str) -> bool:
+    if provider.upper() == "OVN":
+        # ovn-octavia-provider doesn't support HTTP monitors at all.
+        # We got to avoid creating it with ovn.
+        return False
+
+    return req.protocol.value.startswith("http")
 
 
 def update_credentials():
@@ -248,6 +337,7 @@ def manage_loadbalancer(
     lb_port,
     lb_algorithm,
     lb_proto: str,
+    lb_hc: Optional[HealthCheck] = None,
     endpoint_name="lb-consumers",
 ):
     log("Managing load balancer for {}", app_name)
@@ -256,7 +346,14 @@ def manage_loadbalancer(
     fip_net = config["lb-floating-network"]
     manage_secgrps = config["manage-security-groups"]
     lb_manager = LoadBalancer.get_or_create(
-        app_name, str(lb_port), subnet, lb_algorithm, lb_proto, fip_net, manage_secgrps
+        app_name,
+        str(lb_port),
+        subnet,
+        lb_algorithm,
+        lb_proto,
+        lb_hc,
+        fip_net,
+        manage_secgrps,
     )
     lb_manager.update_members([(addr, str(port)) for addr, port in members])
     return lb_manager
@@ -519,14 +616,14 @@ class LoadBalancer:
 
     @classmethod
     def get_or_create(
-        cls, app_name, port, subnet, algorithm, proto, fip_net, manage_secgrps
+        cls, app_name, port, subnet, algorithm, proto, hc, fip_net, manage_secgrps
     ):
         """
         Create a client instance for the given LB.
 
         Returns the proper subclass depending on whether Octavia is available.
         """
-        lb = cls(app_name, port, subnet, algorithm, proto, fip_net, manage_secgrps)
+        lb = cls(app_name, port, subnet, algorithm, proto, hc, fip_net, manage_secgrps)
         if not lb.is_created:
             try:
                 lb.create()
@@ -546,18 +643,20 @@ class LoadBalancer:
             cached_info["subnet"],
             cached_info["algorithm"],
             cached_info.get("proto") or DEFAULT_PROTOCOL,
+            None,
             cached_info["fip_net"],
             cached_info["manage_secgrps"],
         )
 
     def __init__(
-        self, app_name, port, subnet, algorithm, proto, fip_net, manage_secgrps
+        self, app_name, port, subnet, algorithm, proto, hc, fip_net, manage_secgrps
     ):
         self.app_name = app_name
         self.port = port
         self.subnet = subnet
         self.algorithm = algorithm
         self.proto = proto
+        self.hc = hc or DEFAULT_HC_REQ
         self.fip_net = fip_net
         self.manage_secgrps = manage_secgrps
         self.sg_id = None
@@ -718,7 +817,7 @@ class LoadBalancer:
         if lb_healthmonitor_info:
             log("Found loadbalancer healthmonitor: {}", lb_healthmonitor_info)
         else:
-            lb_healthmonitor_info = self._impl.create_healthmonitor(lb_info["provider"])
+            lb_healthmonitor_info = self._impl.create_healthmonitor(self.hc, 0)
             # check if created; some backends don't support it
             if lb_healthmonitor_info:
                 log(
@@ -732,9 +831,10 @@ class LoadBalancer:
 
     def _wait_not_pending(self, show_func):
         lb_status = None
-        for retry in range(30):
+        for _ in range(30):
             lb_status = show_func()["provisioning_status"]
             if not lb_status.startswith("PENDING_"):
+                log("Load balancer {} is not PENDING_ status: {}", self.name, lb_status)
                 break
             sleep(2)
 
@@ -1022,7 +1122,7 @@ class BaseLBImpl:
     def delete_member(self, member):
         raise NotImplementedError()
 
-    def create_healthmonitor(self, provider_type: str):
+    def create_healthmonitor(self, req: HealthCheck, index: int):
         raise NotImplementedError()
 
     def list_healthmonitors(self) -> list:
@@ -1129,28 +1229,40 @@ class OctaviaLBImpl(BaseLBImpl):
             "loadbalancer", "member", "delete", self.name, addr, yaml_output=False
         )
 
-    def create_healthmonitor(self, provider_type: str):
+    def create_healthmonitor(self, req: HealthCheck, index: int):
         """
-        Create an opinionated health monitor
-        designed to monitor the kubernetes master service.
+        Create a health monitor based on the LB requested from the relation.
         Don't need a 'delete_healthmonitor',
         because this will be cleaned up by openstack automatically on lb deletion.
         """
+        lb_info = self.show_loadbalancer()
+        opts = _health_monitor_create_opts(lb_info, req, index, self.proto)
+
+        build_args = [
+            "--delay",
+            str(opts.delay),
+            "--max-retries",
+            str(opts.max_retries),
+            "--timeout",
+            str(opts.timeout),
+            "--type",
+            opts.type,
+        ]
+        if path := opts.url_path:
+            build_args.extend(["--url-path", path])
+        if http_method := opts.http_method:
+            build_args.extend(["--http-method", http_method])
+        if expected_codes := opts.expected_codes:
+            build_args.extend(["--expected-codes", expected_codes])
+
         return _openstack(
             "loadbalancer",
             "healthmonitor",
             "create",
-            "--delay",
-            "5",
-            "--max-retries",
-            "4",
-            "--timeout",
-            "10",
-            "--type",
-            _healthmonitor_type_by_proto(provider_type, self.proto).value,
+            *build_args,
             "--name",
-            self.name,
-            self.name,
+            opts.name,
+            self.name,  # name of the pool
         )
 
     def list_healthmonitors(self) -> list:
@@ -1254,7 +1366,7 @@ class NeutronLBImpl(BaseLBImpl):
         addr, _ = member
         _neutron("lbaas-member-delete", addr, self.name)
 
-    def create_healthmonitor(self, provider_type: str):
+    def create_healthmonitor(self, req: HealthCheck, index: int):
         """not implemented for neutron"""
         return
 

--- a/src/lib/charms/layer/openstack.py
+++ b/src/lib/charms/layer/openstack.py
@@ -25,9 +25,9 @@ from charmhelpers.core.unitdata import kv
 
 from charms.layer import status
 
-
 CACHED_LB_PREFIX = "created_lbs"
 ENDPOINT_TIMEOUT = 30.0  # seconds
+DEFAULT_PROTOCOL = "HTTPS"
 
 # When debugging hooks, for some reason HOME is set to /home/ubuntu, whereas
 # during normal hook execution, it's /root. Set it here to be consistent.
@@ -212,7 +212,12 @@ def _default_subnet(members, endpoint_name):
 
 
 def manage_loadbalancer(
-    app_name, members, lb_port, lb_algorithm, endpoint_name="lb-consumers"
+    app_name,
+    members,
+    lb_port,
+    lb_algorithm,
+    lb_proto: str,
+    endpoint_name="lb-consumers",
 ):
     log("Managing load balancer for {}", app_name)
     config = hookenv.config()
@@ -220,7 +225,7 @@ def manage_loadbalancer(
     fip_net = config["lb-floating-network"]
     manage_secgrps = config["manage-security-groups"]
     lb_manager = LoadBalancer.get_or_create(
-        app_name, str(lb_port), subnet, lb_algorithm, fip_net, manage_secgrps
+        app_name, str(lb_port), subnet, lb_algorithm, lb_proto, fip_net, manage_secgrps
     )
     lb_manager.update_members([(addr, str(port)) for addr, port in members])
     return lb_manager
@@ -482,13 +487,15 @@ class LoadBalancer:
     octavia_available = None
 
     @classmethod
-    def get_or_create(cls, app_name, port, subnet, algorithm, fip_net, manage_secgrps):
+    def get_or_create(
+        cls, app_name, port, subnet, algorithm, proto, fip_net, manage_secgrps
+    ):
         """
         Create a client instance for the given LB.
 
         Returns the proper subclass depending on whether Octavia is available.
         """
-        lb = cls(app_name, port, subnet, algorithm, fip_net, manage_secgrps)
+        lb = cls(app_name, port, subnet, algorithm, proto, fip_net, manage_secgrps)
         if not lb.is_created:
             try:
                 lb.create()
@@ -507,15 +514,19 @@ class LoadBalancer:
             cached_info["port"],
             cached_info["subnet"],
             cached_info["algorithm"],
+            cached_info.get("proto") or DEFAULT_PROTOCOL,
             cached_info["fip_net"],
             cached_info["manage_secgrps"],
         )
 
-    def __init__(self, app_name, port, subnet, algorithm, fip_net, manage_secgrps):
+    def __init__(
+        self, app_name, port, subnet, algorithm, proto, fip_net, manage_secgrps
+    ):
         self.app_name = app_name
         self.port = port
         self.subnet = subnet
         self.algorithm = algorithm
+        self.proto = proto
         self.fip_net = fip_net
         self.manage_secgrps = manage_secgrps
         self.sg_id = None
@@ -555,6 +566,7 @@ class LoadBalancer:
                 self.port,
                 self.subnet,
                 self.algorithm,
+                self.proto,
                 self.fip_net,
                 self.manage_secgrps,
             )
@@ -564,6 +576,7 @@ class LoadBalancer:
                 self.port,
                 self.subnet,
                 self.algorithm,
+                self.proto,
                 self.fip_net,
                 self.manage_secgrps,
             )
@@ -812,6 +825,11 @@ class LoadBalancer:
             self.fip = info["fip"]
             self.address = info["address"]
             self.members = {tuple(m) for m in info["members"]}
+            # handle upgrade from before protocol was cached
+            # This supports the case where prior LBs were created
+            # with HTTPS as the protocol even if the requested protocol
+            # was UDP or TCP.
+            self.proto = info.get("proto") or DEFAULT_PROTOCOL
             self.member_sg_id = info.get("member_sg_id")
             if self.member_sg_id is None and self.is_port_sec_enabled:
                 # handle upgrade from before the member SG was handled
@@ -828,6 +846,7 @@ class LoadBalancer:
                 "port": self.port,
                 "subnet": self.subnet,
                 "algorithm": self.algorithm,
+                "proto": self.proto,
                 "fip_net": self.fip_net,
                 "manage_secgrps": self.manage_secgrps,
                 "sg_id": self.sg_id,
@@ -842,11 +861,12 @@ class LoadBalancer:
 
 
 class BaseLBImpl:
-    def __init__(self, name, port, subnet, algorithm, fip_net, manage_secgrps):
+    def __init__(self, name, port, subnet, algorithm, proto, fip_net, manage_secgrps):
         self.name = name
         self.port = port
         self.subnet = subnet
         self.algorithm = algorithm
+        self.proto = proto
         self.fip_net = fip_net
         self.manage_secgrps = manage_secgrps
 
@@ -1013,7 +1033,7 @@ class OctaviaLBImpl(BaseLBImpl):
             "--name",
             self.name,
             "--protocol",
-            "HTTPS",
+            self.proto.upper(),
             "--protocol-port",
             self.port,
             self.name,
@@ -1040,7 +1060,7 @@ class OctaviaLBImpl(BaseLBImpl):
             "--lb-algorithm",
             self.algorithm,
             "--protocol",
-            "HTTPS",
+            self.proto.upper(),
         )
 
     def delete_pool(self):
@@ -1144,7 +1164,7 @@ class NeutronLBImpl(BaseLBImpl):
             "--name",
             self.name,
             "--protocol",
-            "HTTPS",
+            self.proto.upper(),
             "--protocol-port",
             self.port,
             "--loadbalancer",
@@ -1170,7 +1190,7 @@ class NeutronLBImpl(BaseLBImpl):
             "--lb-algorithm",
             self.algorithm,
             "--protocol",
-            "HTTPS",
+            self.proto.upper(),
         )
 
     def delete_pool(self):

--- a/src/lib/charms/layer/openstack.py
+++ b/src/lib/charms/layer/openstack.py
@@ -1,5 +1,6 @@
 import binascii
 import contextlib
+import enum
 import json
 import re
 import os
@@ -29,6 +30,16 @@ CACHED_LB_PREFIX = "created_lbs"
 ENDPOINT_TIMEOUT = 30.0  # seconds
 DEFAULT_PROTOCOL = "HTTPS"
 
+
+class HC_TYPE(enum.Enum):
+    TLS_HELLO = "TLS-HELLO"
+    HTTP = "HTTP"
+    TCP = "TCP"
+    UDP_CONNECT = "UDP-CONNECT"
+
+
+DEFAULT_HC_TYPE = HC_TYPE.TLS_HELLO
+
 # When debugging hooks, for some reason HOME is set to /home/ubuntu, whereas
 # during normal hook execution, it's /root. Set it here to be consistent.
 os.environ["HOME"] = "/root"
@@ -45,6 +56,26 @@ def log(msg, *args):
 
 def log_err(msg, *args):
     hookenv.log(msg.format(*args), hookenv.ERROR)
+
+
+def _healthmonitor_type_by_proto(provider: str, proto: str) -> HC_TYPE:
+    proto = proto.upper()
+    provider = provider.lower()
+
+    if not provider:
+        return DEFAULT_HC_TYPE
+
+    if provider == "ovn":
+        # OVN can only handle TCP / UDP checks
+        return HC_TYPE.TCP if proto != "UDP" else HC_TYPE.UDP_CONNECT
+
+    if proto == "HTTPS":
+        return DEFAULT_HC_TYPE
+
+    if proto == "TERMINATED_HTTPS":
+        return HC_TYPE.HTTP
+
+    return HC_TYPE.TCP
 
 
 def update_credentials():
@@ -687,7 +718,7 @@ class LoadBalancer:
         if lb_healthmonitor_info:
             log("Found loadbalancer healthmonitor: {}", lb_healthmonitor_info)
         else:
-            lb_healthmonitor_info = self._impl.create_healthmonitor()
+            lb_healthmonitor_info = self._impl.create_healthmonitor(lb_info["provider"])
             # check if created; some backends don't support it
             if lb_healthmonitor_info:
                 log(
@@ -991,7 +1022,7 @@ class BaseLBImpl:
     def delete_member(self, member):
         raise NotImplementedError()
 
-    def create_healthmonitor(self):
+    def create_healthmonitor(self, provider_type: str):
         raise NotImplementedError()
 
     def list_healthmonitors(self) -> list:
@@ -1098,7 +1129,7 @@ class OctaviaLBImpl(BaseLBImpl):
             "loadbalancer", "member", "delete", self.name, addr, yaml_output=False
         )
 
-    def create_healthmonitor(self):
+    def create_healthmonitor(self, provider_type: str):
         """
         Create an opinionated health monitor
         designed to monitor the kubernetes master service.
@@ -1116,7 +1147,7 @@ class OctaviaLBImpl(BaseLBImpl):
             "--timeout",
             "10",
             "--type",
-            "TLS-HELLO",
+            _healthmonitor_type_by_proto(provider_type, self.proto).value,
             "--name",
             self.name,
             self.name,
@@ -1223,7 +1254,7 @@ class NeutronLBImpl(BaseLBImpl):
         addr, _ = member
         _neutron("lbaas-member-delete", addr, self.name)
 
-    def create_healthmonitor(self):
+    def create_healthmonitor(self, provider_type: str):
         """not implemented for neutron"""
         return
 

--- a/src/reactive/openstack.py
+++ b/src/reactive/openstack.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 SUPPORTED_LB_PROTOS = ["udp", "tcp", "https"]
 SUPPORTED_LB_ALGS = ["ROUND_ROBIN", "LEAST_CONNECTIONS", "SOURCE_IP"]
-SUPPORTED_LB_HC_PROTOS = ["http", "https", "tcp"]
+SUPPORTED_LB_HC_PROTOS = ["ping", "http", "https", "tls-hello", "udp-connect", "sctp"]
 
 
 @when_all("snap.installed.openstackclients")
@@ -241,12 +241,14 @@ def _validate_loadbalancer_request(request: "LBRequest") -> "LBResponse":
         error_fields["tls_termination"] = "Not yet supported"
 
     for i, hc in enumerate(request.health_checks):
+        if i > 0:
+            error_fields[f"hc[{i}]"] = "Only supports up to 1 health check"
         if hc.protocol.value not in SUPPORTED_LB_HC_PROTOS:
-            error_fields["hc[{}].protocol".format(i)] = "Must be one of: {}".format(
-                ", ".join(SUPPORTED_LB_PROTOS)
+            error_fields[f"hc[{i}].protocol"] = "Must be one of: {}".format(
+                ", ".join(SUPPORTED_LB_HC_PROTOS)
             )
         if hc.path and hc.protocol.value not in ("http", "https"):
-            error_fields["hc[{}].path".format(i)] = "Only valid with http(s) protocol"
+            error_fields[f"hc[{i}].path"] = "Only valid with http(s) protocol"
 
     remote_port: Optional[int] = None
     config = hookenv.config()
@@ -350,6 +352,7 @@ def manage_loadbalancers_via_lb_consumers():
                 lb_port,
                 _lb_algo(request),
                 _lb_proto(request),
+                request.health_checks[0] if request.health_checks else None,
                 "lb-consumers",
             )
             response.address = lb.fip or lb.address

--- a/src/reactive/openstack.py
+++ b/src/reactive/openstack.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
         Response as LBResponse,
     )
 
-SUPPORTED_LB_PROTOS = ["udp", "tcp"]
+SUPPORTED_LB_PROTOS = ["udp", "tcp", "https"]
 SUPPORTED_LB_ALGS = ["ROUND_ROBIN", "LEAST_CONNECTIONS", "SOURCE_IP"]
 SUPPORTED_LB_HC_PROTOS = ["http", "https", "tcp"]
 
@@ -207,6 +207,17 @@ def _lb_algo(request):
     return None
 
 
+def _lb_proto(request):
+    """
+    Choose a supported protocol for the request.
+    """
+    if not hasattr(request, "protocol") or not request.protocol:
+        return None
+    if request.protocol.value not in SUPPORTED_LB_PROTOS:
+        return None
+    return request.protocol.value.upper()
+
+
 def _validate_loadbalancer_request(request: "LBRequest") -> "LBResponse":
     """
     Validate the incoming request.
@@ -216,7 +227,7 @@ def _validate_loadbalancer_request(request: "LBRequest") -> "LBResponse":
     if not request.public:
         error_fields["public"] = "Only support public loadbalancers"
 
-    if request.protocol.value not in SUPPORTED_LB_PROTOS:
+    if not _lb_proto(request):
         error_fields["protocol"] = "Must be one of: {}".format(
             ", ".join(SUPPORTED_LB_PROTOS)
         )
@@ -297,6 +308,7 @@ def manage_loadbalancers_via_loadbalancer():
                 request.members,
                 lb_port,
                 _lb_algo(request),
+                _lb_proto(request),
                 "loadbalancer",
             )
             request.set_address_port(lb.fip or lb.address, lb.port)
@@ -333,7 +345,12 @@ def manage_loadbalancers_via_lb_consumers():
         try:
             members = [(addr, remote_port) for addr in request.backends]
             lb = layer.openstack.manage_loadbalancer(
-                request.name, members, lb_port, _lb_algo(request), "lb-consumers"
+                request.name,
+                members,
+                lb_port,
+                _lb_algo(request),
+                _lb_proto(request),
+                "lb-consumers",
             )
             response.address = lb.fip or lb.address
             response.error = None

--- a/src/reactive/openstack.py
+++ b/src/reactive/openstack.py
@@ -311,7 +311,7 @@ def manage_loadbalancers_via_loadbalancer():
                 lb_port,
                 _lb_algo(request),
                 _lb_proto(request),
-                "loadbalancer",
+                endpoint_name="loadbalancer",
             )
             request.set_address_port(lb.fip or lb.address, lb.port)
     except layer.openstack.OpenStackError as e:

--- a/tests/integration/test_openstack_integrator_integration.py
+++ b/tests/integration/test_openstack_integrator_integration.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from lightkube.codecs import from_dict
 from lightkube.resources.core_v1 import Node
 
-
 log = logging.getLogger(__name__)
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 import charms.unit_test
 
-
 charms.unit_test.patch_reactive()
 charms.unit_test.patch_module("subprocess")
 charms.unit_test.patch_module("urllib.request")

--- a/tests/unit/test_openstack_integrator.py
+++ b/tests/unit/test_openstack_integrator.py
@@ -268,6 +268,7 @@ def test_default_subnet(_openstack):
 @mock.patch.object(openstack, "LoadBalancer")
 def test_manage_loadbalancer(mock_lb, mock_subnet):
     lb_method = "ROUND_ROBIN"
+    lb_proto = "TCP"
     lb_port = "6443"
     openstack.hookenv.config.return_value = {
         "lb-subnet": "",
@@ -280,13 +281,19 @@ def test_manage_loadbalancer(mock_lb, mock_subnet):
     members = [("1.2.3.4", 80)]
     assert (
         openstack.manage_loadbalancer(
-            "my-ha-app", members, lb_port, lb_method, "lb-consumers"
+            "my-ha-app", members, lb_port, lb_method, lb_proto, "lb-consumers"
         )
         is lb_manager
     )
     mock_subnet.assert_called_once_with(members, "lb-consumers")
     mock_lb.get_or_create.assert_called_once_with(
-        "my-ha-app", lb_port, mock_subnet.return_value, lb_method, "fip-network", False
+        "my-ha-app",
+        lb_port,
+        mock_subnet.return_value,
+        lb_method,
+        lb_proto,
+        "fip-network",
+        False,
     )
     lb_manager.update_members.assert_called_once_with([("1.2.3.4", "80")])
 
@@ -295,7 +302,7 @@ def test_manage_loadbalancer(mock_lb, mock_subnet):
 @mock.patch.object(openstack.LoadBalancer, "_create_member_sg")
 @mock.patch.object(openstack.LoadBalancer, "create")
 def test_get_or_create(create, cms, ams, kv):
-    args = ("app", "80", "subnet", "alg", None, False)
+    args = ("app", "80", "subnet", "alg", "proto", None, False)
     kv().get.return_value = {
         "sg_id": "sg_id",
         "member_sg_id": "member_sg_id",
@@ -346,7 +353,7 @@ def test_get_or_create(create, cms, ams, kv):
 
 def test_create_new(impl, log_err, kv):
     kv().get.return_value = None
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", None, False)
+    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", None, False)
     assert not lb.is_created
     impl.list_loadbalancers.return_value = []
     impl.create_loadbalancer.return_value = {
@@ -409,7 +416,7 @@ def test_create_new(impl, log_err, kv):
 
 def test_create_recover(impl, kv):
     kv().get.return_value = None
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "net", True)
+    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", "net", True)
     impl.list_loadbalancers.return_value = [{"name": "openstack-integrator-1234-app"}]
     impl.show_loadbalancer.return_value = {
         "id": "2345",
@@ -477,7 +484,7 @@ def test_load_from_cache(impl, kv):
 
 def test_delete_loadbalancer(impl, kv):
     kv().get.return_value = None
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "net", True)
+    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", "net", True)
     lb.delete()
 
     impl.get_port_sec_enabled.assert_called_once()
@@ -486,7 +493,7 @@ def test_delete_loadbalancer(impl, kv):
 
 
 def test_wait_not_pending(impl):
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", None, False)
+    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", None, False)
     test_func = mock.Mock(
         side_effect=[
             {"provisioning_status": "PENDING_CREATE"},
@@ -509,7 +516,7 @@ def test_wait_not_pending(impl):
 
 
 def test_find_matching_sg_rule(impl):
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", None, False)
+    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", None, False)
     lb.address = "1.1.1.1"
 
     impl.list_sg_rules.return_value = [{"Port Range": None, "IP Range": None}]
@@ -532,7 +539,7 @@ def test_find_matching_sg_rule(impl):
 
 
 def test_find(impl, log_err):
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", None, False)
+    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", None, False)
     item1 = {"id": 1, "name": "not-lb"}
     item2 = {"id": 2, "name": "openstack-integrator-1234-app"}
     item3 = {"id": 3, "name": "openstack-integrator-1234-app"}
@@ -547,7 +554,7 @@ def test_find(impl, log_err):
 
 def test_member_sg_failure(impl, _openstack):
     impl.find_port.return_value = None
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", None, False)
+    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", None, False)
     lb.address = "1.1.1.1"
     lb.members = {(1, 2)}
     with pytest.raises(openstack.OpenStackLBError) as excinfo:
@@ -556,7 +563,7 @@ def test_member_sg_failure(impl, _openstack):
 
 
 def test_update_members(impl, _openstack):
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", None, False)
+    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", None, False)
     lb.address = "1.1.1.1"
     impl.show_pool.return_value = {"provisioning_status": "ACTIVE"}
     impl.list_sg_rules.return_value = []

--- a/tests/unit/test_openstack_integrator.py
+++ b/tests/unit/test_openstack_integrator.py
@@ -12,6 +12,7 @@ from urllib.error import HTTPError
 import charms.layer
 
 from charms.unit_test import patch_fixture
+from loadbalancer_interface.schemas.v1 import HealthCheck
 import reactive.openstack
 
 openstack = charms.layer.openstack
@@ -281,7 +282,7 @@ def test_manage_loadbalancer(mock_lb, mock_subnet):
     members = [("1.2.3.4", 80)]
     assert (
         openstack.manage_loadbalancer(
-            "my-ha-app", members, lb_port, lb_method, lb_proto, "lb-consumers"
+            "my-ha-app", members, lb_port, lb_method, lb_proto, None, "lb-consumers"
         )
         is lb_manager
     )
@@ -292,6 +293,7 @@ def test_manage_loadbalancer(mock_lb, mock_subnet):
         mock_subnet.return_value,
         lb_method,
         lb_proto,
+        None,
         "fip-network",
         False,
     )
@@ -302,7 +304,7 @@ def test_manage_loadbalancer(mock_lb, mock_subnet):
 @mock.patch.object(openstack.LoadBalancer, "_create_member_sg")
 @mock.patch.object(openstack.LoadBalancer, "create")
 def test_get_or_create(create, cms, ams, kv):
-    args = ("app", "80", "subnet", "alg", "proto", None, False)
+    args = ("app", "80", "subnet", "alg", "proto", None, None, False)
     kv().get.return_value = {
         "sg_id": "sg_id",
         "member_sg_id": "member_sg_id",
@@ -353,7 +355,9 @@ def test_get_or_create(create, cms, ams, kv):
 
 def test_create_new(impl, log_err, kv):
     kv().get.return_value = None
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", None, False)
+    lb = openstack.LoadBalancer(
+        "app", "80", "subnet", "alg", "proto", None, None, False
+    )
     assert not lb.is_created
     impl.list_loadbalancers.return_value = []
     impl.create_loadbalancer.return_value = {
@@ -405,7 +409,7 @@ def test_create_new(impl, log_err, kv):
     impl.list_fips.return_value = []
     lb.create()
     assert lb.sg_id == "sg_id"
-    impl.create_healthmonitor.assert_has_calls([mock.call("amphora")])
+    impl.create_healthmonitor.assert_has_calls([mock.call(openstack.DEFAULT_HC_REQ, 0)])
     impl.create_secgrp.assert_has_calls(
         [
             mock.call("openstack-integrator-1234-app"),
@@ -418,7 +422,9 @@ def test_create_new(impl, log_err, kv):
 
 def test_create_recover(impl, kv):
     kv().get.return_value = None
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", "net", True)
+    lb = openstack.LoadBalancer(
+        "app", "80", "subnet", "alg", "proto", None, "net", True
+    )
     impl.list_loadbalancers.return_value = [{"name": "openstack-integrator-1234-app"}]
     impl.show_loadbalancer.return_value = {
         "id": "2345",
@@ -486,7 +492,9 @@ def test_load_from_cache(impl, kv):
 
 def test_delete_loadbalancer(impl, kv):
     kv().get.return_value = None
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", "net", True)
+    lb = openstack.LoadBalancer(
+        "app", "80", "subnet", "alg", "proto", None, "net", True
+    )
     lb.delete()
 
     impl.get_port_sec_enabled.assert_called_once()
@@ -495,7 +503,9 @@ def test_delete_loadbalancer(impl, kv):
 
 
 def test_wait_not_pending(impl):
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", None, False)
+    lb = openstack.LoadBalancer(
+        "app", "80", "subnet", "alg", "proto", None, None, False
+    )
     test_func = mock.Mock(
         side_effect=[
             {"provisioning_status": "PENDING_CREATE"},
@@ -518,7 +528,9 @@ def test_wait_not_pending(impl):
 
 
 def test_find_matching_sg_rule(impl):
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", None, False)
+    lb = openstack.LoadBalancer(
+        "app", "80", "subnet", "alg", "proto", None, None, False
+    )
     lb.address = "1.1.1.1"
 
     impl.list_sg_rules.return_value = [{"Port Range": None, "IP Range": None}]
@@ -541,7 +553,9 @@ def test_find_matching_sg_rule(impl):
 
 
 def test_find(impl, log_err):
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", None, False)
+    lb = openstack.LoadBalancer(
+        "app", "80", "subnet", "alg", "proto", None, None, False
+    )
     item1 = {"id": 1, "name": "not-lb"}
     item2 = {"id": 2, "name": "openstack-integrator-1234-app"}
     item3 = {"id": 3, "name": "openstack-integrator-1234-app"}
@@ -556,7 +570,9 @@ def test_find(impl, log_err):
 
 def test_member_sg_failure(impl, _openstack):
     impl.find_port.return_value = None
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", None, False)
+    lb = openstack.LoadBalancer(
+        "app", "80", "subnet", "alg", "proto", None, None, False
+    )
     lb.address = "1.1.1.1"
     lb.members = {(1, 2)}
     with pytest.raises(openstack.OpenStackLBError) as excinfo:
@@ -565,7 +581,9 @@ def test_member_sg_failure(impl, _openstack):
 
 
 def test_update_members(impl, _openstack):
-    lb = openstack.LoadBalancer("app", "80", "subnet", "alg", "proto", None, False)
+    lb = openstack.LoadBalancer(
+        "app", "80", "subnet", "alg", "proto", None, None, False
+    )
     lb.address = "1.1.1.1"
     impl.show_pool.return_value = {"provisioning_status": "ACTIVE"}
     impl.list_sg_rules.return_value = []
@@ -844,34 +862,60 @@ def test_normalize_creds(_determine_version, log_err):
 
 
 @pytest.mark.parametrize(
-    "provider,proto, hc_type",
+    "provider,proto,req,args",
     [
-        ("", "anything", "TLS-HELLO"),
-        ("amphora", "TCP", "TCP"),
-        ("amphora", "HTTPS", "TLS-HELLO"),
-        ("amphora", "TERMINATED_HTTPS", "HTTP"),
-        ("ovn", "TCP", "TCP"),
-        ("ovn", "UDP", "UDP-CONNECT"),
+        ("ovn", "HTTPS", "https,6334,/health", ["--type", "TCP"]),
+        ("ovn", "HTTP", "https,6334,/health", ["--type", "TCP"]),
+        ("ovn", "TCP", "https,6334,/health", ["--type", "TCP"]),
+        ("ovn", "UDP", "https,6334,/health", ["--type", "UDP-CONNECT"]),
+        (
+            "amphora",
+            "TCP",
+            "https,6334,/health",
+            [
+                "--type",
+                "HTTPS",
+                "--url-path",
+                "/health",
+                "--http-method",
+                "GET",
+                "--expected-codes",
+                "200-499",
+            ],
+        ),
+        (
+            "amphora",
+            "HTTPS",
+            "https,6334,",
+            [
+                "--type",
+                "TLS-HELLO",
+            ],
+        ),
     ],
 )
 @mock.patch.object(openstack, "_openstack")
-def test_octavia_create_healthmonitor(cmd, provider, proto, hc_type):
-    args = ("app", "80", "subnet", "alg", proto, None, False)
-    lb_impl = openstack.OctaviaLBImpl(*args)
-    lb_impl.create_healthmonitor(provider)
-    cmd.assert_called_with(
-        "loadbalancer",
-        "healthmonitor",
-        "create",
-        "--delay",
-        "5",
-        "--max-retries",
-        "4",
-        "--timeout",
-        "10",
-        "--type",
-        hc_type,
-        "--name",
-        "app",
-        "app",
-    )
+@mock.patch.object(openstack.OctaviaLBImpl, "show_loadbalancer")
+def test_octavia_create_healthmonitor(show_lb, cmd, provider, proto, req, args):
+    lb_args = ("app", "80", "subnet", "alg", proto, None, False)
+    hc_proto, port, path = req.split(",")
+    hc = [HealthCheck()._update(protocol=hc_proto, port=int(port), path=path)]
+    show_lb.return_value = {"provider": provider, "name": "app"}
+    lb_impl = openstack.OctaviaLBImpl(*lb_args)
+    for index, req in enumerate(hc):
+        lb_impl.create_healthmonitor(req, index)
+        cmd.assert_called_with(
+            "loadbalancer",
+            "healthmonitor",
+            "create",
+            "--delay",
+            "5",
+            "--max-retries",
+            "3",
+            "--timeout",
+            "30",
+            *args,
+            "--name",
+            "app",
+            "app",
+        )

--- a/tests/unit/test_openstack_integrator.py
+++ b/tests/unit/test_openstack_integrator.py
@@ -360,6 +360,7 @@ def test_create_new(impl, log_err, kv):
         "id": "1234",
         "vip_address": "1.1.1.1",
         "vip_port_id": "4321",
+        "provider": "amphora",
     }
     impl.show_loadbalancer.return_value = {"provisioning_status": "ACTIVE"}
     impl.show_pool.return_value = {"provisioning_status": "ACTIVE"}
@@ -404,6 +405,7 @@ def test_create_new(impl, log_err, kv):
     impl.list_fips.return_value = []
     lb.create()
     assert lb.sg_id == "sg_id"
+    impl.create_healthmonitor.assert_has_calls([mock.call("amphora")])
     impl.create_secgrp.assert_has_calls(
         [
             mock.call("openstack-integrator-1234-app"),
@@ -839,3 +841,37 @@ def test_normalize_creds(_determine_version, log_err):
 
     attrs["endpoint-tls-ca"] = attrs.pop("cacertificates")[0]
     assert openstack._normalize_creds(attrs) == expected
+
+
+@pytest.mark.parametrize(
+    "provider,proto, hc_type",
+    [
+        ("", "anything", "TLS-HELLO"),
+        ("amphora", "TCP", "TCP"),
+        ("amphora", "HTTPS", "TLS-HELLO"),
+        ("amphora", "TERMINATED_HTTPS", "HTTP"),
+        ("ovn", "TCP", "TCP"),
+        ("ovn", "UDP", "UDP-CONNECT"),
+    ],
+)
+@mock.patch.object(openstack, "_openstack")
+def test_octavia_create_healthmonitor(cmd, provider, proto, hc_type):
+    args = ("app", "80", "subnet", "alg", proto, None, False)
+    lb_impl = openstack.OctaviaLBImpl(*args)
+    lb_impl.create_healthmonitor(provider)
+    cmd.assert_called_with(
+        "loadbalancer",
+        "healthmonitor",
+        "create",
+        "--delay",
+        "5",
+        "--max-retries",
+        "4",
+        "--timeout",
+        "10",
+        "--type",
+        hc_type,
+        "--name",
+        "app",
+        "app",
+    )

--- a/tests/unit/test_reactive_openstack.py
+++ b/tests/unit/test_reactive_openstack.py
@@ -122,7 +122,8 @@ class Protocol(enum.Enum):
             [mock.MagicMock(protocol=mock.MagicMock(value="ftp"))],
             {
                 "hc[0].path": "Only valid with http(s) protocol",
-                "hc[0].protocol": "Must be one of: udp, tcp, https",
+                "hc[0].protocol": "Must be one of: ping, http, "
+                "https, tls-hello, udp-connect, sctp",
             },
         ),
         (

--- a/tests/unit/test_reactive_openstack.py
+++ b/tests/unit/test_reactive_openstack.py
@@ -109,7 +109,7 @@ class Protocol(enum.Enum):
         (
             "protocol",
             Protocol.http,
-            "Must be one of: udp, tcp",
+            "Must be one of: udp, tcp, https",
         ),
         (
             "algorithm",
@@ -122,7 +122,7 @@ class Protocol(enum.Enum):
             [mock.MagicMock(protocol=mock.MagicMock(value="ftp"))],
             {
                 "hc[0].path": "Only valid with http(s) protocol",
-                "hc[0].protocol": "Must be one of: udp, tcp",
+                "hc[0].protocol": "Must be one of: udp, tcp, https",
             },
         ),
         (

--- a/tox.ini
+++ b/tox.ini
@@ -27,13 +27,13 @@ deps =
     git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
     python-openstackclient
     -r src/wheelhouse.txt
-commands = 
+commands =
     pytest --tb native -s -vv \
        --cov-report term-missing --cov=src \
        {posargs} {toxinidir}/tests/unit
 
 [testenv:lint]
-deps = 
+deps =
     flake8
     black
 commands =
@@ -56,6 +56,5 @@ commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s {posargs
 [testenv:validate-wheelhouse]
 deps =
     git+https://github.com/juju/charm-tools.git
-    path<17
 allowlist_externals = {toxinidir}/tests/validate-wheelhouse.sh
 commands = {toxinidir}/tests/validate-wheelhouse.sh


### PR DESCRIPTION
[LP#2110255](https://bugs.launchpad.net/charm-openstack-integrator/+bug/2110255)

Properly request TCP protocol (not HTTPS) load-balancers over `openstack:lb-consumers` and `openstack:loadbalancer` relations

for Kubernetes this is a better LB according to [upstream docs](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/high-availability/#create-load-balancer-for-kube-apiserver)

> In a cloud environment you should place your control plane nodes behind a TCP forwarding load balancer. This load balancer distributes traffic to all healthy control plane nodes in its target list. The health check for an apiserver is a TCP check on the port the kube-apiserver listens on (default value :6443).

```sh
~|⇒ openstack loadbalancer list
+--------------------------------------+-------------------------------------------------------+----------------------------------+---------------+---------------------+------------------+----------+
| id                                   | name                                                  | project_id                       | vip_address   | provisioning_status | operating_status | provider |
+--------------------------------------+-------------------------------------------------------+----------------------------------+---------------+---------------------+------------------+----------+
| b076fe31-89b1-4741-87c4-82996df694af | openstack-integrator-41cb93baffb7-api-server-external | 2a6ee35f84a74023b7342e12d316bd05 | 10.145.211.63 | ACTIVE              | ONLINE           | amphora  |
+--------------------------------------+-------------------------------------------------------+----------------------------------+---------------+---------------------+------------------+----------+
~|⇒ openstack loadbalancer listener list
+--------------------------------------+--------------------------------------+-------------------------------------------------------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name                                                  | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+-------------------------------------------------------+----------------------------------+----------+---------------+----------------+
| daadeb55-ec1e-472b-ae09-d8c8ca826609 | 0c269c09-b3b3-4823-aa8a-404e0e5e0126 | openstack-integrator-41cb93baffb7-api-server-external | 2a6ee35f84a74023b7342e12d316bd05 | TCP      |           443 | True           |
+--------------------------------------+--------------------------------------+-------------------------------------------------------+----------------------------------+----------+---------------+----------------+
~|⇒ openstack loadbalancer healthmonitor list
+--------------------------------------+-------------------------------------------------------+----------------------------------+-------+----------------+
| id                                   | name                                                  | project_id                       | type  | admin_state_up |
+--------------------------------------+-------------------------------------------------------+----------------------------------+-------+----------------+
| 6f2d50dd-5588-4a8e-8fc1-6045045fc8b1 | openstack-integrator-41cb93baffb7-api-server-external | 2a6ee35f84a74023b7342e12d316bd05 | HTTPS | True           |
+--------------------------------------+-------------------------------------------------------+----------------------------------+-------+----------------+
~|⇒ openstack loadbalancer pool list         
+--------------------------------------+-------------------------------------------------------+----------------------------------+---------------------+----------+--------------+----------------+
| id                                   | name                                                  | project_id                       | provisioning_status | protocol | lb_algorithm | admin_state_up |
+--------------------------------------+-------------------------------------------------------+----------------------------------+---------------------+----------+--------------+----------------+
| 0c269c09-b3b3-4823-aa8a-404e0e5e0126 | openstack-integrator-41cb93baffb7-api-server-external | 2a6ee35f84a74023b7342e12d316bd05 | ACTIVE              | TCP      | ROUND_ROBIN  | True           |
+--------------------------------------+-------------------------------------------------------+----------------------------------+---------------------+----------+--------------+----------------+
~|⇒ openstack loadbalancer member list 0c269c09-b3b3-4823-aa8a-404e0e5e0126
+--------------------------------------+----------------+----------------------------------+---------------------+----------------+---------------+------------------+--------+
| id                                   | name           | project_id                       | provisioning_status | address        | protocol_port | operating_status | weight |
+--------------------------------------+----------------+----------------------------------+---------------------+----------------+---------------+------------------+--------+
| 31d9108b-cc25-429d-9c30-75e4e76f2c3e | 10.145.211.235 | 2a6ee35f84a74023b7342e12d316bd05 | ACTIVE              | 10.145.211.235 |          6443 | ONLINE           |      1 |
| 72312905-cbf3-4926-b68b-77ba6afd8375 | 10.145.211.232 | 2a6ee35f84a74023b7342e12d316bd05 | ACTIVE              | 10.145.211.232 |          6443 | ONLINE           |      1 |
| 3f47cbf9-4c91-4bea-bd6b-b3ed0cbb36b1 | 10.145.211.214 | 2a6ee35f84a74023b7342e12d316bd05 | ACTIVE              | 10.145.211.214 |          6443 | ONLINE           |      1 |
+--------------------------------------+----------------+----------------------------------+---------------------+----------------+---------------+------------------+--------+

```