### PR TITLE
chore: mark optional provides endpoints as optional in metadata

### DIFF
--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -15,10 +15,13 @@ tags: ['openstack', 'native', 'integration']
 provides:
   clients:
     interface: openstack-integration
+    optional: true
   credentials:
     interface: keystone-credentials
+    optional: true
   loadbalancer:
     interface: public-address
+    optional: true
     # Use of this relation is strongly discouraged in favor of the more
     # explicit lb-consumers relation.
   lb-consumers:


### PR DESCRIPTION
Mark `clients`, `credentials`, and `loadbalancer` (provides) as `optional: true`. Each serves a distinct deployment scenario; a valid deployment needs at least one but each is individually optional.