### PR TITLE
feat(lb): add lb-provider config for octavia provider selection

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -175,3 +175,11 @@ options:
       proxied using juju's model-config juju-*-proxy settings.
       (See https://documentation.ubuntu.com/juju/latest/reference/juju-cli/list-of-juju-cli-commands/model-config/).
     default: false
+  lb-provider:
+    description: |
+      Octavia provider driver (e.g. "amphora" or "ovn") to use when this
+      charm creates load balancers for other charms related on the
+      loadbalancer endpoint. If unset, the cloud's default provider is used.
+    type: string
+    default: ""
+

--- a/src/lib/charms/layer/openstack.py
+++ b/src/lib/charms/layer/openstack.py
@@ -1138,14 +1138,18 @@ class OctaviaLBImpl(BaseLBImpl):
         return _openstack("loadbalancer", "list")
 
     def create_loadbalancer(self):
-        return _openstack(
+        args = [
             "loadbalancer",
             "create",
             "--name",
             self.name,
             "--vip-subnet-id",
             self.subnet,
-        )
+        ]
+        provider = hookenv.config().get("lb-provider")
+        if provider:
+            args += ["--provider", provider]
+        return _openstack(*args)
 
     def show_loadbalancer(self):
         return _openstack("loadbalancer", "show", self.name)


### PR DESCRIPTION
Allow operators to choose the Octavia provider driver used when this charm creates load balancers on behalf of related charms.

- add `lb-provider` config option defaulting to the cloud's default
- pass `--provider` to `loadbalancer create` when the option is set

Background - Sunbeam creates OVN loadbalancer by default. In recent versions also Amphora was added and this patch allows to select it. Amphora LB is needed for Canonicalk8s as it is Layer 7 LB.

I tested it manually with ck8s on Sunbeam by refreshing the charm with locally built and I got ck8s deployed with Amphora LB active.