### PR TITLE
Pin RELEASE_BRANCH to release_1.36 on release_1.36

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -35,5 +35,5 @@ parts:
     build-environment:
     - CHARM_LAYERS_DIR: $CRAFT_STAGE/tmp/layers/
     - CHARM_INTERFACES_DIR: $CRAFT_STAGE/tmp/interfaces/
-    - RELEASE_BRANCH: main
+    - RELEASE_BRANCH: release_1.36
 


### PR DESCRIPTION
## Summary
- set `RELEASE_BRANCH` to `release_1.36` in `charmcraft.yaml`
- ensure reactive charm builds on `release_1.36` use the matching release branch for layer selection

## Testing
- verified `charmcraft.yaml` contains `RELEASE_BRANCH: release_1.36`
